### PR TITLE
Add multi-provider bridge support and versioning

### DIFF
--- a/bridge_agents.py
+++ b/bridge_agents.py
@@ -1,0 +1,556 @@
+"""Shared provider adapters and agent helpers for Chat Bridge scripts."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import AsyncGenerator, Dict, Iterable, List, Optional
+
+import httpx
+
+STALL_TIMEOUT_SEC = 90
+MAX_TOKENS = 800
+
+
+@dataclass
+class Turn:
+    """Lightweight representation of a single utterance in the dialogue."""
+
+    author: str  # "human", "a", or "b"
+    text: str
+
+
+@dataclass
+class ProviderSpec:
+    key: str
+    label: str
+    kind: str  # chatml | anthropic | gemini | ollama | openai
+    default_model: str
+    default_system: str
+    needs_key: bool
+    key_env: Optional[str]
+    model_env: Optional[str]
+    description: str
+
+
+def _env(name: Optional[str]) -> Optional[str]:
+    if not name:
+        return None
+    val = os.getenv(name)
+    return val.strip() if isinstance(val, str) and val.strip() else None
+
+
+PROVIDER_REGISTRY: Dict[str, ProviderSpec] = {
+    "openai": ProviderSpec(
+        key="openai",
+        label="OpenAI",
+        kind="chatml",
+        default_model=_env("OPENAI_MODEL") or "gpt-4.1-mini",
+        default_system="You are ChatGPT. Be concise, helpful, and witty.",
+        needs_key=True,
+        key_env="OPENAI_API_KEY",
+        model_env="OPENAI_MODEL",
+        description="OpenAI Chat Completions API using the latest turbo-tier GPT-4.1 Mini.",
+    ),
+    "anthropic": ProviderSpec(
+        key="anthropic",
+        label="Anthropic",
+        kind="anthropic",
+        default_model=_env("ANTHROPIC_MODEL") or "claude-3-5-sonnet-20240620",
+        default_system="You are Claude. Be concise, helpful, and witty.",
+        needs_key=True,
+        key_env="ANTHROPIC_API_KEY",
+        model_env="ANTHROPIC_MODEL",
+        description="Anthropic Messages API targeting Claude 3.5 Sonnet (turbo-tier).",
+    ),
+    "gemini": ProviderSpec(
+        key="gemini",
+        label="Gemini",
+        kind="gemini",
+        default_model=_env("GEMINI_MODEL") or "gemini-1.5-pro-latest",
+        default_system="You are Gemini. Respond with structured, thoughtful, and well-cited answers when possible.",
+        needs_key=True,
+        key_env="GEMINI_API_KEY",
+        model_env="GEMINI_MODEL",
+        description="Google Gemini API using the latest 1.5 Pro turbo configuration.",
+    ),
+    "ollama": ProviderSpec(
+        key="ollama",
+        label="Ollama",
+        kind="ollama",
+        default_model=_env("OLLAMA_MODEL") or "llama3.1:8b-instruct",
+        default_system="You are a local Ollama assistant. Be direct, cite sources when available, and keep responses crisp.",
+        needs_key=False,
+        key_env=None,
+        model_env="OLLAMA_MODEL",
+        description="Local Ollama server chat endpoint (defaults to llama3.1 8B instruct turbo).",
+    ),
+    "lmstudio": ProviderSpec(
+        key="lmstudio",
+        label="LM Studio",
+        kind="chatml",
+        default_model=_env("LMSTUDIO_MODEL") or "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF",
+        default_system="You are an LM Studio-hosted assistant. Reason carefully and keep answers grounded in evidence.",
+        needs_key=False,
+        key_env=None,
+        model_env="LMSTUDIO_MODEL",
+        description="LM Studio local OpenAI-compatible server (turbo tuned).",
+    ),
+}
+
+
+class OpenAIChat:
+    """Minimal OpenAI (or OpenAI-compatible) streaming client."""
+
+    def __init__(self, model: str, api_key: Optional[str] = None, base_url: Optional[str] = None):
+        self.model = model
+        self.api_key = api_key
+        base = base_url or "https://api.openai.com/v1"
+        self.url = f"{base.rstrip('/')}/chat/completions"
+        self.headers = {"Content-Type": "application/json"}
+        if api_key:
+            self.headers["Authorization"] = f"Bearer {api_key}"
+
+    async def stream(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.7,
+        max_tokens: int = MAX_TOKENS,
+    ) -> AsyncGenerator[str, None]:
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "stream": True,
+            "max_tokens": max_tokens,
+        }
+        async with httpx.AsyncClient(timeout=httpx.Timeout(STALL_TIMEOUT_SEC)) as client:
+            async with client.stream("POST", self.url, headers=self.headers, json=payload) as r:
+                r.raise_for_status()
+                req_id = r.headers.get("x-request-id") or r.headers.get("request-id")
+                if req_id:
+                    logging.getLogger("bridge").info("OpenAI-style request-id: %s", req_id)
+                async for line in r.aiter_lines():
+                    if not line:
+                        continue
+                    if line.startswith("data: "):
+                        data = line[6:].strip()
+                        if data == "[DONE]":
+                            break
+                        with contextlib.suppress(Exception):
+                            obj = json.loads(data)
+                            delta = obj["choices"][0]["delta"].get("content")
+                            if delta:
+                                yield delta
+
+
+class AnthropicChat:
+    """Anthropic Messages API client with fallback to the legacy completions endpoint."""
+
+    def __init__(self, api_key: str, model: str):
+        self.api_key = api_key
+        self.model = model
+        self.base_messages = "https://api.anthropic.com/v1/messages"
+        self.base_complete = "https://api.anthropic.com/v1/complete"
+        self.msg_headers = {
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+            "accept": "text/event-stream",
+        }
+        self.cpl_headers = {
+            "x-api-key": api_key,
+            "content-type": "application/json",
+            "accept": "text/event-stream",
+        }
+
+    async def _stream_messages(
+        self,
+        system_prompt: str,
+        messages_for_claude: List[Dict[str, str]],
+        temperature: float,
+        max_tokens: int,
+    ) -> AsyncGenerator[str, None]:
+        payload = {
+            "model": self.model,
+            "system": system_prompt,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "messages": messages_for_claude,
+            "stream": True,
+        }
+        async with httpx.AsyncClient(timeout=httpx.Timeout(STALL_TIMEOUT_SEC)) as client:
+            async with client.stream("POST", self.base_messages, headers=self.msg_headers, json=payload) as r:
+                if r.status_code in (404, 405):
+                    raise httpx.HTTPStatusError(
+                        "Messages endpoint unsupported; falling back.",
+                        request=r.request,
+                        response=r,
+                    )
+                r.raise_for_status()
+                req_id = r.headers.get("x-request-id") or r.headers.get("request-id")
+                if req_id:
+                    logging.getLogger("bridge").info("Anthropic request-id: %s", req_id)
+                async for raw in r.aiter_lines():
+                    if not raw:
+                        continue
+                    if raw.startswith("data: "):
+                        data = raw[6:].strip()
+                        if data == "[DONE]":
+                            break
+                        with contextlib.suppress(Exception):
+                            obj = json.loads(data)
+                            if obj.get("type") in ("content_block_delta", "content_block"):
+                                delta = obj.get("delta", {})
+                                if delta.get("type") == "text_delta":
+                                    text = delta.get("text")
+                                    if text:
+                                        yield text
+
+    async def _stream_complete(
+        self,
+        prompt: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> AsyncGenerator[str, None]:
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "max_tokens_to_sample": max_tokens,
+            "temperature": temperature,
+            "stream": True,
+        }
+        async with httpx.AsyncClient(timeout=httpx.Timeout(STALL_TIMEOUT_SEC)) as client:
+            async with client.stream("POST", self.base_complete, headers=self.cpl_headers, json=payload) as r:
+                r.raise_for_status()
+                req_id = r.headers.get("x-request-id") or r.headers.get("request-id")
+                if req_id:
+                    logging.getLogger("bridge").info("Anthropic request-id (complete): %s", req_id)
+                async for raw in r.aiter_lines():
+                    if not raw:
+                        continue
+                    if raw.startswith("data: "):
+                        data = raw[6:].strip()
+                        if data == "[DONE]":
+                            break
+                        with contextlib.suppress(Exception):
+                            obj = json.loads(data)
+                            if "completion" in obj:
+                                text = obj.get("completion")
+                                if text:
+                                    yield text
+                            elif obj.get("type") == "completion" and "delta" in obj:
+                                delta = obj["delta"]
+                                if isinstance(delta, str):
+                                    yield delta
+
+    async def stream(
+        self,
+        system_prompt: str,
+        messages_for_claude: List[Dict[str, str]],
+        temperature: float = 0.7,
+        max_tokens: int = MAX_TOKENS,
+    ) -> AsyncGenerator[str, None]:
+        try:
+            async for piece in self._stream_messages(system_prompt, messages_for_claude, temperature, max_tokens):
+                yield piece
+            return
+        except httpx.HTTPStatusError as exc:
+            if exc.response is None or exc.response.status_code not in (404, 405):
+                raise
+        except httpx.RequestError:
+            pass
+
+        prompt_lines: List[str] = []
+        if system_prompt:
+            prompt_lines.append(f"[System]: {system_prompt}")
+        for item in messages_for_claude:
+            role = item.get("role", "user")
+            parts = []
+            for block in item.get("content", []):
+                if block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+            text = "\n".join(parts).strip()
+            if not text:
+                continue
+            label = "Assistant" if role == "assistant" else "User"
+            prompt_lines.append(f"[{label}]: {text}")
+        prompt_lines.append("\n[Assistant]:")
+        prompt = "\n".join(prompt_lines)
+
+        async for piece in self._stream_complete(prompt, temperature, max_tokens):
+            yield piece
+
+
+class GeminiChat:
+    """Thin wrapper over the Gemini REST API (non-streaming with async generator)."""
+
+    def __init__(self, api_key: str, model: str):
+        self.api_key = api_key
+        self.model = model
+        self.base_url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
+
+    async def stream(
+        self,
+        system_instruction: str,
+        contents: List[Dict[str, object]],
+        temperature: float = 0.7,
+        max_tokens: int = MAX_TOKENS,
+    ) -> AsyncGenerator[str, None]:
+        payload: Dict[str, object] = {
+            "contents": contents,
+            "generationConfig": {
+                "temperature": temperature,
+                "maxOutputTokens": max_tokens,
+            },
+        }
+        if system_instruction:
+            payload["systemInstruction"] = {
+                "role": "system",
+                "parts": [{"text": system_instruction}],
+            }
+
+        params = {"key": self.api_key}
+        async with httpx.AsyncClient(timeout=httpx.Timeout(STALL_TIMEOUT_SEC)) as client:
+            response = await client.post(self.base_url, params=params, json=payload)
+            response.raise_for_status()
+            data = response.json()
+
+        texts: List[str] = []
+        for candidate in data.get("candidates", []):
+            content = candidate.get("content", {})
+            parts = content.get("parts", []) if isinstance(content, dict) else []
+            for part in parts:
+                txt = part.get("text") if isinstance(part, dict) else None
+                if txt:
+                    texts.append(txt)
+        final = "\n".join(texts).strip()
+        if final:
+            yield final
+
+
+class OllamaChat:
+    """Client for the Ollama chat endpoint."""
+
+    def __init__(self, model: str, host: Optional[str] = None):
+        base = host or os.getenv("OLLAMA_HOST", "http://localhost:11434")
+        self.base = base.rstrip("/")
+        self.model = model
+
+    async def stream(
+        self,
+        messages: List[Dict[str, str]],
+        system_prompt: str,
+        temperature: float = 0.7,
+        max_tokens: int = MAX_TOKENS,
+    ) -> AsyncGenerator[str, None]:
+        payload: Dict[str, object] = {
+            "model": self.model,
+            "messages": messages,
+            "stream": True,
+            "options": {
+                "temperature": temperature,
+                "num_predict": max_tokens,
+            },
+        }
+        if system_prompt:
+            payload["system"] = system_prompt
+
+        url = f"{self.base}/api/chat"
+        async with httpx.AsyncClient(timeout=httpx.Timeout(STALL_TIMEOUT_SEC)) as client:
+            async with client.stream("POST", url, json=payload) as r:
+                r.raise_for_status()
+                async for line in r.aiter_lines():
+                    if not line:
+                        continue
+                    with contextlib.suppress(Exception):
+                        data = json.loads(line)
+                        if data.get("done"):
+                            break
+                        if "message" in data:
+                            content = data["message"].get("content")
+                            if content:
+                                yield content
+                        elif "response" in data:
+                            resp = data.get("response")
+                            if resp:
+                                yield resp
+
+
+def provider_choices() -> List[str]:
+    return list(PROVIDER_REGISTRY.keys())
+
+
+def get_spec(key: str) -> ProviderSpec:
+    if key not in PROVIDER_REGISTRY:
+        raise KeyError(f"Unknown provider: {key}")
+    return PROVIDER_REGISTRY[key]
+
+
+def resolve_model(provider_key: str, override: Optional[str] = None, agent_env: Optional[str] = None) -> str:
+    if override:
+        return override
+    agent_override = _env(agent_env) if agent_env else None
+    if agent_override:
+        return agent_override
+    spec = get_spec(provider_key)
+    env_override = _env(spec.model_env)
+    if env_override:
+        return env_override
+    return spec.default_model
+
+
+def ensure_credentials(provider_key: str) -> Optional[str]:
+    spec = get_spec(provider_key)
+    if not spec.needs_key:
+        return None
+    key = _env(spec.key_env)
+    if not key:
+        raise RuntimeError(
+            f"Missing API key for {spec.label}. Set {spec.key_env} in your environment or .env file."
+        )
+    return key
+
+
+def select_turns(turns: Iterable[Turn], mem_rounds: int) -> List[Turn]:
+    items = list(turns)
+    if mem_rounds <= 0 or mem_rounds >= len(items):
+        return items
+    return items[-mem_rounds:]
+
+
+def build_chatml(turns: List[Turn], agent_id: str, system_prompt: str) -> List[Dict[str, str]]:
+    messages: List[Dict[str, str]] = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    for turn in turns:
+        role = "assistant" if turn.author == agent_id else "user"
+        messages.append({"role": role, "content": turn.text})
+    return messages
+
+
+def build_anthropic(turns: List[Turn], agent_id: str) -> List[Dict[str, object]]:
+    formatted: List[Dict[str, object]] = []
+    for turn in turns:
+        role = "assistant" if turn.author == agent_id else "user"
+        formatted.append({
+            "role": role,
+            "content": [{"type": "text", "text": turn.text}],
+        })
+    return formatted
+
+
+def build_gemini(turns: List[Turn], agent_id: str) -> List[Dict[str, object]]:
+    formatted: List[Dict[str, object]] = []
+    for turn in turns:
+        role = "model" if turn.author == agent_id else "user"
+        formatted.append({
+            "role": role,
+            "parts": [{"text": turn.text}],
+        })
+    return formatted
+
+
+def build_ollama(turns: List[Turn], agent_id: str) -> List[Dict[str, str]]:
+    formatted: List[Dict[str, str]] = []
+    for turn in turns:
+        role = "assistant" if turn.author == agent_id else "user"
+        formatted.append({"role": role, "content": turn.text})
+    return formatted
+
+
+@dataclass
+class AgentRuntime:
+    agent_id: str
+    provider_key: str
+    model: str
+    temperature: float
+    system_prompt: str
+    client: object
+
+    @property
+    def spec(self) -> ProviderSpec:
+        return get_spec(self.provider_key)
+
+    @property
+    def label(self) -> str:
+        return self.spec.label
+
+    @property
+    def identifier(self) -> str:
+        return f"{self.provider_key}:{self.model}"
+
+    def stream_reply(self, turns: Iterable[Turn], mem_rounds: int) -> AsyncGenerator[str, None]:
+        recent = select_turns(turns, mem_rounds)
+        if self.provider_key in {"openai", "lmstudio"}:
+            messages = build_chatml(recent, self.agent_id, self.system_prompt)
+            return self.client.stream(messages, temperature=self.temperature)
+        if self.provider_key == "anthropic":
+            messages = build_anthropic(recent, self.agent_id)
+            return self.client.stream(
+                system_prompt=self.system_prompt,
+                messages_for_claude=messages,
+                temperature=self.temperature,
+            )
+        if self.provider_key == "gemini":
+            contents = build_gemini(recent, self.agent_id)
+            return self.client.stream(
+                system_instruction=self.system_prompt,
+                contents=contents,
+                temperature=self.temperature,
+            )
+        if self.provider_key == "ollama":
+            messages = build_ollama(recent, self.agent_id)
+            return self.client.stream(
+                messages=messages,
+                system_prompt=self.system_prompt,
+                temperature=self.temperature,
+            )
+        raise RuntimeError(f"Unsupported provider: {self.provider_key}")
+
+
+def create_agent(agent_id: str, provider_key: str, model: str, temperature: float, system_prompt: str) -> AgentRuntime:
+    if provider_key == "openai":
+        api_key = ensure_credentials(provider_key)
+        client = OpenAIChat(model=model, api_key=api_key)
+    elif provider_key == "anthropic":
+        api_key = ensure_credentials(provider_key)
+        client = AnthropicChat(api_key=api_key, model=model)
+    elif provider_key == "gemini":
+        api_key = ensure_credentials(provider_key)
+        client = GeminiChat(api_key=api_key, model=model)
+    elif provider_key == "ollama":
+        client = OllamaChat(model=model)
+    elif provider_key == "lmstudio":
+        base = os.getenv("LMSTUDIO_BASE_URL", "http://localhost:1234/v1")
+        client = OpenAIChat(model=model, api_key=None, base_url=base)
+    else:
+        raise RuntimeError(f"Unsupported provider: {provider_key}")
+
+    return AgentRuntime(
+        agent_id=agent_id,
+        provider_key=provider_key,
+        model=model,
+        temperature=temperature,
+        system_prompt=system_prompt,
+        client=client,
+    )
+
+
+__all__ = [
+    "AgentRuntime",
+    "PROVIDER_REGISTRY",
+    "ProviderSpec",
+    "Turn",
+    "create_agent",
+    "ensure_credentials",
+    "get_spec",
+    "provider_choices",
+    "resolve_model",
+    "select_turns",
+    "STALL_TIMEOUT_SEC",
+]
+

--- a/chat_bridge_pro.py
+++ b/chat_bridge_pro.py
@@ -1,80 +1,84 @@
 # chat_bridge_pro.py
 """
-Chat Bridge Pro — Async, streaming, logged conversation between OpenAI (ChatGPT) and Anthropic (Claude)
+Chat Bridge Pro — stream two AI assistants through a single console.
 
-What’s new:
-  • Auto-saves a human-readable Markdown transcript per session:
-      transcripts/<TIMESTAMP>__<STARTER_SLUG>.md
-  • Optional per-session file log (logs/<TIMESTAMP>__<STARTER_SLUG>.log)
-  • CLI flags: --max-rounds, --mem-rounds, --openai-model, --anthropic-model, --temp-a, --temp-b
-  • Retains: SQLite logging, streaming, loop detector, Anthropic messages→completions fallback
-
-Usage:
-  python chat_bridge_pro.py --max-rounds 60 --mem-rounds 10
+What's new in this release?
+  • Choose between OpenAI, Anthropic, Gemini, Ollama, or LM Studio for either side.
+  • Latest "turbo" defaults per provider (e.g. GPT-4.1 Mini, Claude 3.5 Sonnet, Gemini 1.5 Pro).
+  • Interactive multi-choice selector at runtime plus backwards-compatible CLI flags.
+  • Shared provider adapters with graceful streaming fallbacks and local-host support.
+  • Project-wide semantic versioning exposed via --version.
 """
 
-import os
-import sys
-import re
-import json
-import sqlite3
-import asyncio
-import logging
-import contextlib
-import argparse
-from datetime import datetime
-from dataclasses import dataclass, field
-from typing import AsyncGenerator, Dict, List, Tuple
+from __future__ import annotations
 
-import httpx
-from dotenv import load_dotenv
+import argparse
+import asyncio
+import contextlib
+import logging
+import os
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
 from difflib import SequenceMatcher
+from typing import AsyncGenerator, Dict, Iterable, List, Tuple
+
+from dotenv import load_dotenv
+
+from bridge_agents import (
+    AgentRuntime,
+    Turn,
+    STALL_TIMEOUT_SEC,
+    create_agent,
+    get_spec,
+    provider_choices,
+    resolve_model,
+)
+from version import __version__
+
 
 # ───────────────────────── Config / Env ─────────────────────────
 
 load_dotenv()
 
-DEFAULT_OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
-DEFAULT_ANTHROPIC_MODEL = os.getenv("ANTHROPIC_MODEL", "claude-3-5-sonnet")
+DEFAULT_PROVIDER_A = os.getenv("BRIDGE_PROVIDER_A", "openai")
+DEFAULT_PROVIDER_B = os.getenv("BRIDGE_PROVIDER_B", "anthropic")
 
-OPENAI_KEY = os.getenv("OPENAI_API_KEY", "")
-ANTHROPIC_KEY = os.getenv("ANTHROPIC_API_KEY", "")
-
-if not OPENAI_KEY or not ANTHROPIC_KEY:
-    print("ERROR: Missing OPENAI_API_KEY or ANTHROPIC_API_KEY in environment / .env")
-    sys.exit(1)
+STOP_WORDS = {"goodbye", "end chat", "terminate", "stop", "that is all"}
+REPEAT_WINDOW = 6
+REPEAT_THRESHOLD = 0.92
 
 DB_PATH = "bridge.db"
 GLOBAL_LOG = "chat_bridge.log"
 TRANSCRIPTS_DIR = "transcripts"
 SESSION_LOGS_DIR = "logs"
 
-STOP_WORDS = {"goodbye", "end chat", "terminate", "stop", "that is all"}
-STALL_TIMEOUT_SEC = 90
-
-REPEAT_WINDOW = 6
-REPEAT_THRESHOLD = 0.92
 
 # ───────────────────────── Utilities ─────────────────────────
 
-def ensure_dirs():
+
+def ensure_dirs() -> None:
     os.makedirs(TRANSCRIPTS_DIR, exist_ok=True)
     os.makedirs(SESSION_LOGS_DIR, exist_ok=True)
 
+
 def safe_slug(text: str, max_len: int = 80) -> str:
-    # collapse whitespace, remove path-nasties, keep alnum + dash + underscore
     text = " ".join(text.strip().split())
     text = text.lower()
     text = re.sub(r"[^a-z0-9_\- ]+", "", text)
     text = re.sub(r"\s+", "-", text)
     return text[:max_len] if text else "session"
 
+
 def now_stamp() -> str:
-    # 2025-09-22_14-55-12 (file-system friendly, local time)
     return datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
 
 def similar(a: str, b: str) -> float:
     return SequenceMatcher(None, a, b).ratio()
+
 
 def is_repetitive(history: List[str], window: int = REPEAT_WINDOW, threshold: float = REPEAT_THRESHOLD) -> bool:
     recent = history[-window:]
@@ -82,79 +86,92 @@ def is_repetitive(history: List[str], window: int = REPEAT_WINDOW, threshold: fl
         return False
     pairs: List[Tuple[str, str]] = []
     for i in range(len(recent) - 1):
-        pairs.append((recent[i], recent[i+1]))
+        pairs.append((recent[i], recent[i + 1]))
     for i in range(len(recent) - 2):
-        pairs.append((recent[i], recent[i+2]))
+        pairs.append((recent[i], recent[i + 2]))
     scores = [similar(x, y) for x, y in pairs]
     if not scores:
         return False
     high = [s for s in scores if s >= threshold]
     return len(high) >= max(2, len(scores) // 2)
 
-def contains_stop_word(text: str) -> bool:
+
+def contains_stop_word(text: str, stop_words: Iterable[str]) -> bool:
     lower = text.lower()
-    return any(sw in lower for sw in STOP_WORDS)
+    return any(sw in lower for sw in stop_words)
 
-# ───────────────────────── Logging setup ─────────────────────────
 
-def setup_global_logging():
+# ───────────────────────── Logging ─────────────────────────
+
+
+def setup_global_logging() -> None:
     logging.basicConfig(
         filename=GLOBAL_LOG,
         level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(message)s"
+        format="%(asctime)s %(levelname)s %(message)s",
     )
+
 
 def make_session_logger(path: str) -> logging.Logger:
     logger = logging.getLogger(f"session_{os.path.basename(path)}")
     logger.setLevel(logging.INFO)
-    # prevent duplicate handlers if rerun in same process
-    if not any(isinstance(h, logging.FileHandler) and h.baseFilename == os.path.abspath(path)
-               for h in logger.handlers):
-        fh = logging.FileHandler(path, encoding="utf-8")
-        fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
-        logger.addHandler(fh)
+    if not any(
+        isinstance(h, logging.FileHandler) and h.baseFilename == os.path.abspath(path)
+        for h in logger.handlers
+    ):
+        handler = logging.FileHandler(path, encoding="utf-8")
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+        logger.addHandler(handler)
     return logger
 
+
 # ───────────────────────── SQLite ─────────────────────────
+
 
 def init_db(path: str = DB_PATH) -> None:
     con = sqlite3.connect(path)
     cur = con.cursor()
-    cur.execute("""
-    CREATE TABLE IF NOT EXISTS conversations (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        started_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        openai_model TEXT,
-        anthropic_model TEXT,
-        starter TEXT
-    );
-    """)
-    cur.execute("""
-    CREATE TABLE IF NOT EXISTS messages (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        conversation_id INTEGER,
-        provider TEXT,
-        role TEXT,
-        content TEXT,
-        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        tokens_est INTEGER,
-        FOREIGN KEY(conversation_id) REFERENCES conversations(id)
-    );
-    """)
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS conversations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            started_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            openai_model TEXT,
+            anthropic_model TEXT,
+            starter TEXT
+        );
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            conversation_id INTEGER,
+            provider TEXT,
+            role TEXT,
+            content TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            tokens_est INTEGER,
+            FOREIGN KEY(conversation_id) REFERENCES conversations(id)
+        );
+        """
+    )
     con.commit()
     con.close()
 
-def create_conversation(openai_model: str, anthropic_model: str, starter: str) -> int:
+
+def create_conversation(agent_a: AgentRuntime, agent_b: AgentRuntime, starter: str) -> int:
     con = sqlite3.connect(DB_PATH)
     cur = con.cursor()
     cur.execute(
         "INSERT INTO conversations(openai_model, anthropic_model, starter) VALUES (?, ?, ?);",
-        (openai_model, anthropic_model, starter)
+        (agent_a.identifier, agent_b.identifier, starter),
     )
     con.commit()
     cid = cur.lastrowid
     con.close()
     return cid
+
 
 def log_message_sql(cid: int, provider: str, role: str, content: str) -> None:
     con = sqlite3.connect(DB_PATH)
@@ -162,249 +179,46 @@ def log_message_sql(cid: int, provider: str, role: str, content: str) -> None:
     tokens_est = max(1, len(content.split()))
     cur.execute(
         "INSERT INTO messages(conversation_id, provider, role, content, tokens_est) VALUES (?, ?, ?, ?, ?);",
-        (cid, provider, role, content, tokens_est)
+        (cid, provider, role, content, tokens_est),
     )
     con.commit()
     con.close()
 
-# ───────────────────────── Providers (Streaming) ─────────────────────────
 
-class OpenAIChat:
-    """Minimal client for /v1/chat/completions with streaming."""
-    def __init__(self, api_key: str, model: str):
-        self.key = api_key
-        self.model = model
-        self.base_url = "https://api.openai.com/v1/chat/completions"
-        self.headers = {
-            "Authorization": f"Bearer {self.key}",
-            "Content-Type": "application/json",
-        }
+# ───────────────────────── Conversation helpers ─────────────────────────
 
-    async def stream(
-        self,
-        messages: List[Dict[str, str]],
-        temperature: float = 0.7,
-        max_tokens: int = 800
-    ) -> AsyncGenerator[str, None]:
-        payload = {
-            "model": self.model,
-            "messages": messages,
-            "temperature": temperature,
-            "stream": True,
-            "max_tokens": max_tokens
-        }
-        async with httpx.AsyncClient(timeout=httpx.Timeout(STALL_TIMEOUT_SEC)) as client:
-            async with client.stream("POST", self.base_url, headers=self.headers, json=payload) as r:
-                r.raise_for_status()
-                # capture request id if present
-                req_id = r.headers.get("x-request-id") or r.headers.get("request-id")
-                if req_id:
-                    logging.getLogger("bridge").info(f"OpenAI request-id: {req_id}")
-                async for line in r.aiter_lines():
-                    if not line:
-                        continue
-                    if line.startswith("data: "):
-                        data = line[6:].strip()
-                        if data == "[DONE]":
-                            break
-                        with contextlib.suppress(Exception):
-                            obj = json.loads(data)
-                            delta = obj["choices"][0]["delta"].get("content")
-                            if delta:
-                                yield delta
-
-class AnthropicChat:
-    """
-    Adaptive Anthropic client:
-      - Try /v1/messages with SSE first.
-      - On 404/405 (or network fail), fall back to /v1/complete streaming.
-    """
-    def __init__(self, api_key: str, model: str):
-        self.key = api_key
-        self.model = model
-        self.base_messages = "https://api.anthropic.com/v1/messages"
-        self.base_complete = "https://api.anthropic.com/v1/complete"
-        self.msg_headers = {
-            "x-api-key": self.key,
-            "anthropic-version": "2023-06-01",
-            "content-type": "application/json",
-            "accept": "text/event-stream",
-        }
-        self.cpl_headers = {
-            "x-api-key": self.key,
-            "content-type": "application/json",
-            "accept": "text/event-stream",
-        }
-
-    @staticmethod
-    def _to_prompt_from_messages(system_prompt: str, anthro_msgs: List[Dict[str, str]]) -> str:
-        lines: List[str] = []
-        if system_prompt:
-            lines.append(f"[System]: {system_prompt}")
-        for item in anthro_msgs:
-            role = item.get("role", "user")
-            parts = []
-            for blk in item.get("content", []):
-                if blk.get("type") == "text":
-                    parts.append(blk.get("text", ""))
-            text = "\n".join(parts).strip()
-            if not text:
-                continue
-            if role == "user":
-                lines.append(f"[User (ChatGPT)]: {text}")
-            else:
-                lines.append(f"[Assistant (Claude)]: {text}")
-        lines.append("\n[Assistant (Claude)]:")
-        return "\n".join(lines)
-
-    async def _stream_messages(
-        self,
-        system_prompt: str,
-        messages_for_claude: List[Dict[str, str]],
-        temperature: float,
-        max_tokens: int
-    ) -> AsyncGenerator[str, None]:
-        payload = {
-            "model": self.model,
-            "system": system_prompt,
-            "max_tokens": max_tokens,
-            "temperature": temperature,
-            "messages": messages_for_claude,
-            "stream": True
-        }
-        async with httpx.AsyncClient(timeout=httpx.Timeout(STALL_TIMEOUT_SEC)) as client:
-            async with client.stream("POST", self.base_messages, headers=self.msg_headers, json=payload) as r:
-                if r.status_code in (404, 405):
-                    text = await r.aread()
-                    raise httpx.HTTPStatusError(
-                        "Messages endpoint unsupported; falling back.",
-                        request=r.request, response=r
-                    )
-                r.raise_for_status()
-                req_id = r.headers.get("x-request-id") or r.headers.get("request-id")
-                if req_id:
-                    logging.getLogger("bridge").info(f"Anthropic request-id: {req_id}")
-                async for raw in r.aiter_lines():
-                    if not raw:
-                        continue
-                    if raw.startswith("data: "):
-                        data = raw[6:].strip()
-                        if data == "[DONE]":
-                            break
-                        with contextlib.suppress(Exception):
-                            obj = json.loads(data)
-                            if obj.get("type") in ("content_block_delta", "content_block"):
-                                delta = obj.get("delta", {})
-                                if delta.get("type") == "text_delta":
-                                    txt = delta.get("text")
-                                    if txt:
-                                        yield txt
-
-    async def _stream_complete(
-        self,
-        prompt: str,
-        temperature: float,
-        max_tokens: int
-    ) -> AsyncGenerator[str, None]:
-        payload = {
-            "model": self.model,
-            "prompt": prompt,
-            "max_tokens_to_sample": max_tokens,
-            "temperature": temperature,
-            "stream": True
-        }
-        async with httpx.AsyncClient(timeout=httpx.Timeout(STALL_TIMEOUT_SEC)) as client:
-            async with client.stream("POST", self.base_complete, headers=self.cpl_headers, json=payload) as r:
-                r.raise_for_status()
-                req_id = r.headers.get("x-request-id") or r.headers.get("request-id")
-                if req_id:
-                    logging.getLogger("bridge").info(f"Anthropic request-id (complete): {req_id}")
-                async for raw in r.aiter_lines():
-                    if not raw:
-                        continue
-                    if raw.startswith("data: "):
-                        data = raw[6:].strip()
-                        if data == "[DONE]":
-                            break
-                        with contextlib.suppress(Exception):
-                            obj = json.loads(data)
-                            if "completion" in obj:
-                                txt = obj.get("completion")
-                                if txt:
-                                    yield txt
-                            elif obj.get("type") == "completion" and "delta" in obj:
-                                delta = obj["delta"]
-                                if isinstance(delta, str):
-                                    yield delta
-
-    async def stream(
-        self,
-        system_prompt: str,
-        messages_for_claude: List[Dict[str, str]],
-        temperature: float = 0.7,
-        max_tokens: int = 800
-    ) -> AsyncGenerator[str, None]:
-        try:
-            async for piece in self._stream_messages(system_prompt, messages_for_claude, temperature, max_tokens):
-                yield piece
-            return
-        except httpx.HTTPStatusError as e:
-            if e.response is None or e.response.status_code not in (404, 405):
-                raise
-        except httpx.RequestError:
-            pass
-        prompt = self._to_prompt_from_messages(system_prompt, messages_for_claude)
-        async for piece in self._stream_complete(prompt, temperature, max_tokens):
-            yield piece
-
-# ───────────────────────── Conversation State ─────────────────────────
 
 @dataclass
-class History:
-    msgs_openai: List[Dict[str, str]] = field(default_factory=list)
-    msgs_anthropic: List[Dict[str, str]] = field(default_factory=list)
+class ConversationHistory:
+    turns: List[Turn] = field(default_factory=list)
     flat_texts: List[str] = field(default_factory=list)
 
-    def add_openai(self, role: str, content: str) -> None:
-        self.msgs_openai.append({"role": role, "content": content})
-        self.flat_texts.append(content)
+    def add_turn(self, author: str, text: str) -> None:
+        self.turns.append(Turn(author=author, text=text))
+        self.flat_texts.append(text)
 
-    def add_anthropic(self, role: str, content: str) -> None:
-        self.msgs_anthropic.append({"role": role, "content": [{"type": "text", "text": content}]})
-        self.flat_texts.append(content)
-
-    def tail_openai(self, n: int) -> List[Dict[str, str]]:
-        msgs = self.msgs_openai
-        if msgs and msgs[0]["role"] == "system":
-            head = [msgs[0]]
-            body = msgs[1:]
-            return head + body[-n:]
-        return msgs[-n:]
-
-    def tail_anthropic(self, n: int) -> List[Dict[str, str]]:
-        return self.msgs_anthropic[-n:]
-
-# ───────────────────────── Transcript helpers ─────────────────────────
 
 @dataclass
 class Transcript:
-    # store lines as we go so we don't need to requery DB to write the .md
     lines: List[str] = field(default_factory=list)
 
-    def start(self, conv_id: int, started_at: str, openai_model: str, anthropic_model: str, starter: str):
+    def start(self, conv_id: int, started_at: str, starter: str, agent_a: AgentRuntime, agent_b: AgentRuntime) -> None:
+        tag_a = agent_tag(agent_a)
+        tag_b = agent_tag(agent_b)
         self.lines.append(f"# Conversation {conv_id}: {starter}\n")
         self.lines.append(f"*Started at {started_at}*  ")
-        self.lines.append(f"*OpenAI model: {openai_model}, Anthropic model: {anthropic_model}*\n")
+        self.lines.append(
+            f"*{tag_a}: {agent_a.model} | {tag_b}: {agent_b.model}*\n"
+        )
 
-    def add(self, provider: str, role: str, timestamp: str, text: str):
-        who = f"{provider.capitalize()} ({role})"
+    def add(self, actor_label: str, role: str, timestamp: str, text: str) -> None:
+        who = f"{actor_label} ({role})"
         self.lines.append(f"**{who}** [{timestamp}]:\n\n{text}\n")
 
-    def dump(self, path: str):
-        with open(path, "w", encoding="utf-8") as f:
-            f.write("\n\n".join(self.lines))
+    def dump(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write("\n\n".join(self.lines))
 
-# ───────────────────────── Streaming collector ─────────────────────────
 
 async def stream_collect(gen: AsyncGenerator[str, None]) -> str:
     chunks: List[str] = []
@@ -414,53 +228,147 @@ async def stream_collect(gen: AsyncGenerator[str, None]) -> str:
     print()
     return "".join(chunks).strip()
 
-# ───────────────────────── Main Orchestrator ─────────────────────────
 
-async def run_bridge(args):
+def resolve_system_prompt(provider_key: str, agent_id: str) -> str:
+    env_name = "BRIDGE_SYSTEM_A" if agent_id == "a" else "BRIDGE_SYSTEM_B"
+    env_val = os.getenv(env_name)
+    if env_val and env_val.strip():
+        return env_val.strip()
+    return get_spec(provider_key).default_system
+
+
+def agent_tag(agent: AgentRuntime) -> str:
+    side = "A" if agent.agent_id == "a" else "B"
+    return f"Agent {side} – {agent.label}"
+
+
+def list_providers() -> List[str]:
+    return provider_choices()
+
+
+def parse_provider_choice(value: str, options: List[str]) -> str | None:
+    cleaned = value.strip().lower()
+    if not cleaned:
+        return None
+    if cleaned.isdigit():
+        idx = int(cleaned) - 1
+        if 0 <= idx < len(options):
+            return options[idx]
+        return None
+    if cleaned in options:
+        return cleaned
+    return None
+
+
+def interactive_provider_selection(
+    provider_a: str,
+    provider_b: str,
+    model_a: str,
+    model_b: str,
+) -> Tuple[str, str, str, str]:
+    options = list_providers()
+    print("\nAvailable providers:")
+    for idx, key in enumerate(options, start=1):
+        spec = get_spec(key)
+        print(f"  {idx}) {spec.label:<9} – default model: {spec.default_model} | {spec.description}")
+
+    spec_a = get_spec(provider_a)
+    spec_b = get_spec(provider_b)
+    print(
+        f"Current selection → Agent A: {spec_a.label} ({model_a}), Agent B: {spec_b.label} ({model_b})"
+    )
+    choice = input("Choose providers as 'A,B' or press Enter to keep: ").strip()
+
+    prev_a, prev_b = provider_a, provider_b
+    if choice:
+        parts = [p.strip() for p in choice.split(",") if p.strip()]
+        if len(parts) == 2:
+            maybe_a = parse_provider_choice(parts[0], options)
+            maybe_b = parse_provider_choice(parts[1], options)
+            if maybe_a:
+                provider_a = maybe_a
+            else:
+                print("⚠️  Invalid Agent A provider selection; keeping previous value.")
+            if maybe_b:
+                provider_b = maybe_b
+            else:
+                print("⚠️  Invalid Agent B provider selection; keeping previous value.")
+        else:
+            print("⚠️  Expected two comma-separated choices. Keeping existing providers.")
+
+    if provider_a != prev_a:
+        model_a = resolve_model(provider_a, override=None, agent_env="BRIDGE_MODEL_A")
+        print(f"Agent A switched to {get_spec(provider_a).label}. Using model {model_a}.")
+    if provider_b != prev_b:
+        model_b = resolve_model(provider_b, override=None, agent_env="BRIDGE_MODEL_B")
+        print(f"Agent B switched to {get_spec(provider_b).label}. Using model {model_b}.")
+
+    override_a = input(f"Agent A model override [{model_a}]: ").strip()
+    if override_a:
+        model_a = override_a
+    override_b = input(f"Agent B model override [{model_b}]: ").strip()
+    if override_b:
+        model_b = override_b
+
+    return provider_a, provider_b, model_a, model_b
+
+
+# ───────────────────────── Runner ─────────────────────────
+
+
+async def run_bridge(args) -> None:
     ensure_dirs()
     setup_global_logging()
     init_db()
 
-    # Prompt
+    provider_a = args.provider_a
+    provider_b = args.provider_b
+    model_a = resolve_model(provider_a, override=args.model_a, agent_env="BRIDGE_MODEL_A")
+    model_b = resolve_model(provider_b, override=args.model_b, agent_env="BRIDGE_MODEL_B")
+
     starter = input("Starter prompt (blank = default): ").strip()
     if not starter:
-        starter = "Hello Claude—tell ChatGPT a clever riddle and why it matters. Keep it playful."
+        starter = "Hello—have each model trade their sharpest teaching trick and critique it."
 
-    # Conversation metadata & filenames
+    provider_a, provider_b, model_a, model_b = interactive_provider_selection(
+        provider_a, provider_b, model_a, model_b
+    )
+
+    system_a = resolve_system_prompt(provider_a, "a")
+    system_b = resolve_system_prompt(provider_b, "b")
+
+    try:
+        agent_a = create_agent("a", provider_a, model_a, args.temp_a, system_a)
+        agent_b = create_agent("b", provider_b, model_b, args.temp_b, system_b)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}")
+        sys.exit(1)
+
     ts = now_stamp()
     slug = safe_slug(starter)
     md_path = os.path.join(TRANSCRIPTS_DIR, f"{ts}__{slug}.md")
     session_log_path = os.path.join(SESSION_LOGS_DIR, f"{ts}__{slug}.log")
     session_logger = make_session_logger(session_log_path)
 
-    # Clients
-    openai = OpenAIChat(OPENAI_KEY, args.openai_model)
-    claude = AnthropicChat(ANTHROPIC_KEY, args.anthropic_model)
+    cid = create_conversation(agent_a, agent_b, starter)
 
-    # DB row
-    cid = create_conversation(args.openai_model, args.anthropic_model, starter)
+    history = ConversationHistory()
+    history.add_turn("human", starter)
+    log_message_sql(cid, agent_a.provider_key, "user", starter)
 
-    # History & transcript header
-    history = History()
-    history.add_openai("system", "You are ChatGPT. Be concise, helpful, and witty.")
-    claude_system = "You are Claude. Be concise, helpful, and witty."
-
-    # record first user message
-    history.add_openai("user", starter)
-    log_message_sql(cid, "openai", "user", starter)
-
-    # transcript header
     started_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     transcript = Transcript()
-    transcript.start(cid, started_at, args.openai_model, args.anthropic_model, starter)
-    transcript.add("openai", "user", started_at, starter)
+    transcript.start(cid, started_at, starter, agent_a, agent_b)
+    transcript.add(agent_tag(agent_a), "user", started_at, starter)
 
-    current = "openai"
+    print(f"\nChat Bridge v{__version__}")
+    print(f"Transcript: {md_path}")
+    print(f"Session log: {session_log_path}\n")
+
+    agents: Dict[str, AgentRuntime] = {"a": agent_a, "b": agent_b}
+    current_id = "a"
     rounds = 0
     bridge_logger = logging.getLogger("bridge")
-
-    print(f"\nTranscript will be saved to: {md_path}")
-    print(f"Session log: {session_log_path}\n")
 
     try:
         while rounds < args.max_rounds:
@@ -468,93 +376,116 @@ async def run_bridge(args):
             print(f"\n—— Round {rounds} ——")
 
             if is_repetitive(history.flat_texts):
-                print("⚠️  Loop detected. Ending chat before we bore ourselves to tears.")
+                print("⚠️  Loop detected. Ending chat before it spirals.")
                 break
 
-            if current == "openai":
-                print("[OpenAI] ", end="", flush=True)
-                messages = history.tail_openai(args.mem_rounds)
-                gen = openai.stream(messages, temperature=args.temp_a)
+            agent = agents[current_id]
+            label = agent_tag(agent)
+            print(f"[{label}] ", end="", flush=True)
+
+            gen = agent.stream_reply(history.turns, args.mem_rounds)
+            try:
                 reply = await asyncio.wait_for(stream_collect(gen), timeout=STALL_TIMEOUT_SEC)
-                if not reply:
-                    print("…(no reply from OpenAI)")
-                    break
+            except asyncio.TimeoutError:
+                print("…timeout waiting for response.")
+                break
 
-                log_message_sql(cid, "openai", "assistant", reply)
-                history.add_openai("assistant", reply)
-                history.add_anthropic("user", reply)
+            if not reply:
+                print("…(no reply)")
+                break
 
-                nowt = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                transcript.add("openai", "assistant", nowt, reply)
-                session_logger.info(f"OpenAI assistant: {reply[:5000]}")
+            log_message_sql(cid, agent.provider_key, "assistant", reply)
+            history.add_turn(agent.agent_id, reply)
 
-                if contains_stop_word(reply):
-                    print("🛑 Stop word detected (OpenAI). Ending chat.")
-                    break
+            nowt = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            transcript.add(label, "assistant", nowt, reply)
+            session_logger.info(f"{label}: {reply[:5000]}")
 
-                current = "anthropic"
+            if contains_stop_word(reply, STOP_WORDS):
+                print("🛑 Stop word detected. Ending chat.")
+                break
 
-            else:
-                print("[Anthropic] ", end="", flush=True)
-                anthro_msgs = history.tail_anthropic(args.mem_rounds)
-                gen = claude.stream(
-                    system_prompt=claude_system,
-                    messages_for_claude=anthro_msgs,
-                    temperature=args.temp_b
-                )
-                reply = await asyncio.wait_for(stream_collect(gen), timeout=STALL_TIMEOUT_SEC)
-                if not reply:
-                    print("…(no reply from Anthropic)")
-                    break
-
-                log_message_sql(cid, "anthropic", "assistant", reply)
-                history.add_anthropic("assistant", reply)
-                history.add_openai("user", reply)
-
-                nowt = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                transcript.add("anthropic", "assistant", nowt, reply)
-                session_logger.info(f"Anthropic assistant: {reply[:5000]}")
-
-                if contains_stop_word(reply):
-                    print("🛑 Stop word detected (Anthropic). Ending chat.")
-                    break
-
-                current = "openai"
+            other_id = "b" if current_id == "a" else "a"
+            current_id = other_id
 
             if is_repetitive(history.flat_texts):
                 print("⚠️  Loop detected after this round. Calling it.")
                 break
 
-        print(f"\nConversation finished.\nMarkdown: {md_path}\nLogs: {session_log_path}  |  Global: {GLOBAL_LOG}")
+        print(
+            f"\nConversation finished.\nMarkdown: {md_path}\nLogs: {session_log_path}  |  Global: {GLOBAL_LOG}"
+        )
 
     except KeyboardInterrupt:
-        print("\nInterrupted by you. Cheerio.")
-    except asyncio.TimeoutError:
-        print("\n⏱️  A provider stalled beyond timeout. Stopping.")
-    except Exception as e:
-        bridge_logger.exception("Unhandled error: %s", e)
-        print(f"\nUnexpected error: {e}")
+        print("\nInterrupted by user. Until next time.")
+    except Exception as exc:
+        bridge_logger.exception("Unhandled error: %s", exc)
+        print(f"\nUnexpected error: {exc}")
     finally:
-        # Always write the transcript at the end (even if cut short)
-        try:
+        with contextlib.suppress(Exception):
             transcript.dump(md_path)
-        except Exception as e:
-            print(f"Failed to write transcript: {e}")
+
 
 # ───────────────────────── CLI ─────────────────────────
 
+
 def parse_args():
-    p = argparse.ArgumentParser(description="OpenAI ↔ Anthropic chat bridge with per-session Markdown transcripts.")
-    p.add_argument("--max-rounds", type=int, default=30, help="Max total replies across both agents.")
-    p.add_argument("--mem-rounds", type=int, default=8, help="How many recent exchanges each side sees.")
-    p.add_argument("--openai-model", type=str, default=DEFAULT_OPENAI_MODEL, help="OpenAI chat model.")
-    p.add_argument("--anthropic-model", type=str, default=DEFAULT_ANTHROPIC_MODEL, help="Anthropic model.")
-    p.add_argument("--temp-a", type=float, default=0.7, help="Temperature for OpenAI.")
-    p.add_argument("--temp-b", type=float, default=0.7, help="Temperature for Anthropic.")
-    return p.parse_args()
+    choices = list_providers()
+    parser = argparse.ArgumentParser(
+        description="Stream conversations between two AI providers with logging and transcripts."
+    )
+    parser.add_argument("--max-rounds", type=int, default=30, help="Max total replies across both agents.")
+    parser.add_argument("--mem-rounds", type=int, default=8, help="How many recent turns each side sees.")
+    parser.add_argument(
+        "--provider-a",
+        choices=choices,
+        default=DEFAULT_PROVIDER_A,
+        help="Provider for Agent A (first speaker).",
+    )
+    parser.add_argument(
+        "--provider-b",
+        choices=choices,
+        default=DEFAULT_PROVIDER_B,
+        help="Provider for Agent B (second speaker).",
+    )
+    parser.add_argument(
+        "--model-a",
+        dest="model_a",
+        type=str,
+        default=None,
+        help="Model override for Agent A (defaults follow provider turbo tiers).",
+    )
+    parser.add_argument(
+        "--model-b",
+        dest="model_b",
+        type=str,
+        default=None,
+        help="Model override for Agent B (defaults follow provider turbo tiers).",
+    )
+    parser.add_argument(
+        "--openai-model",
+        dest="model_a",
+        type=str,
+        default=None,
+        help="Alias for --model-a (backwards compatibility).",
+    )
+    parser.add_argument(
+        "--anthropic-model",
+        dest="model_b",
+        type=str,
+        default=None,
+        help="Alias for --model-b (backwards compatibility).",
+    )
+    parser.add_argument("--temp-a", type=float, default=0.7, help="Sampling temperature for Agent A.")
+    parser.add_argument("--temp-b", type=float, default=0.7, help="Sampling temperature for Agent B.")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    return parser.parse_args()
+
 
 # ───────────────────────── Entry ─────────────────────────
 
+
 if __name__ == "__main__":
-    args = parse_args()
-    asyncio.run(run_bridge(args))
+    arguments = parse_args()
+    asyncio.run(run_bridge(arguments))
+

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -1,18 +1,24 @@
 # Roles Configuration Guide
 
-The roles edition (`chat_bridge_roles.py`) lets you script bespoke personas for each provider before a conversation begins. It loads a JSON file (default: `roles.json`) and merges it with built-in defaults.
+The roles edition (`chat_bridge_roles.py`) loads a JSON file before each session to
+decide which providers, models, system prompts, and safeguards to use. The file is
+merged with built-in defaults so you can override only the pieces you care about.
 
 ## File Structure
 
 ```json
 {
-  "openai": {
-    "system": "System prompt for ChatGPT",
-    "guidelines": ["Optional bullet points shown to ChatGPT"]
+  "agent_a": {
+    "provider": "openai",
+    "model": null,
+    "system": "System prompt for the first agent",
+    "guidelines": ["Optional bullet points appended to the system prompt"]
   },
-  "anthropic": {
-    "system": "System prompt for Claude",
-    "guidelines": ["Optional bullet points shown to Claude"]
+  "agent_b": {
+    "provider": "anthropic",
+    "model": null,
+    "system": "System prompt for the second agent",
+    "guidelines": ["Optional bullet points for the second agent"]
   },
   "stop_words": ["wrap up", "end chat"],
   "temp_a": 0.6,
@@ -22,21 +28,35 @@ The roles edition (`chat_bridge_roles.py`) lets you script bespoke personas for 
 
 ### Keys
 
-- **`openai.system` / `anthropic.system`** – base instructions injected as the respective system prompts.
-- **`openai.guidelines` / `anthropic.guidelines`** – extra bullet points appended to the system prompt. Omit or leave empty for a plain prompt.
-- **`stop_words`** – optional list of phrases that will halt the conversation if either model says them.
-- **`temp_a` / `temp_b`** – default temperatures supplied to the CLI if no override is passed.
+- **`agent_a.provider` / `agent_b.provider`** – which backend drives each side of the
+  conversation. Supported values are `openai`, `anthropic`, `gemini`, `ollama`, and
+  `lmstudio`.
+- **`model`** – optional explicit model name for that provider. Leave it `null` (or omit it)
+  to fall back to the latest turbo default or any `BRIDGE_MODEL_*` / provider-specific
+  environment overrides.
+- **`system`** – base system prompt injected into the provider before the chat begins.
+- **`guidelines`** – optional bullet points appended to the system prompt.
+- **`stop_words`** – list of phrases that will halt the run if either agent says them.
+- **`temp_a` / `temp_b`** – default temperatures if you do not provide CLI overrides.
 
-All fields are optional; anything you leave out falls back to the defaults baked into the script.
+All fields are optional. Missing properties inherit from the defaults bundled with the
+repository.
+
+## Legacy Format
+
+Older versions of the project used top-level `openai` / `anthropic` keys. Those files
+continue to work—the loader automatically upgrades them to the new schema.
 
 ## Workflow
 
-1. Duplicate `roles.json` (or point `--roles` to a new file).
-2. Edit the JSON to capture the tone, constraints, or safety instructions you need.
-3. Run the bridge with the roles file:
+1. Duplicate `roles.json` or point `--roles` to a new file.
+2. Edit the JSON to capture the providers, tones, and safeguards you need.
+3. Run the bridge:
    ```bash
    python chat_bridge_roles.py --roles my_roles.json --max-rounds 40 --mem-rounds 10
    ```
-4. Adjust stop words or temperatures to shape the flow of the conversation.
+4. Use the interactive prompt (or CLI flags) to switch providers or models on the fly.
 
-If the file is missing, the script will write the default configuration to help you get started.
+If the roles file is missing the script writes the default configuration to help you get
+started.
+

--- a/roles.json
+++ b/roles.json
@@ -1,13 +1,17 @@
 {
-  "openai": {
-    "system": "You are ChatGPT. Be concise, helpful, truthful, and witty. Prioritise verifiable facts and clear reasoning.",
+  "agent_a": {
+    "provider": "openai",
+    "model": null,
+    "system": "You are ChatGPT. Be concise, truthful, and witty. Prioritise verifiable facts and clear reasoning.",
     "guidelines": [
       "When comparing sources, cite examples and name key scholars or texts.",
       "If asked for probabilities, explain your methodology and uncertainty.",
       "Prefer structured answers with brief lists, then a crisp conclusion."
     ]
   },
-  "anthropic": {
+  "agent_b": {
+    "provider": "anthropic",
+    "model": null,
     "system": "You are Claude. Be concise, compassionate, truthful, and reflective. Balance clarity with nuance.",
     "guidelines": [
       "Surface connections across traditions without overclaiming equivalence.",
@@ -19,3 +23,4 @@
   "temp_a": 0.6,
   "temp_b": 0.7
 }
+

--- a/version.py
+++ b/version.py
@@ -1,0 +1,4 @@
+"""Project version string."""
+
+__version__ = "1.1.0"
+


### PR DESCRIPTION
## Summary
- add shared provider adapters so either agent can use OpenAI, Anthropic, Gemini, Ollama, or LM Studio with turbo defaults
- rework both bridge entry points to offer interactive provider/model selection, expanded CLI flags, and version reporting
- refresh the roles schema, sample configuration, and docs to match the new multi-provider workflow

## Testing
- python -m compileall bridge_agents.py chat_bridge_pro.py chat_bridge_roles.py

------
https://chatgpt.com/codex/tasks/task_e_68d306d914588324baa54b26077f4c55