### PR TITLE
Add setup requirements and launcher script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+httpx
+python-dotenv

--- a/start_chat_bridge.sh
+++ b/start_chat_bridge.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "Updating repository..."
+git pull --ff-only
+
+if [ ! -d ".venv" ]; then
+  echo "Creating virtual environment at .venv"
+  python3 -m venv .venv
+fi
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+pip install --upgrade pip
+pip install -r requirements.txt
+
+exec python chat_bridge_roles.py


### PR DESCRIPTION
## Summary
- add a requirements.txt capturing the runtime dependencies
- introduce a launcher script that updates the repo, ensures a virtual environment, installs requirements, and runs chat_bridge_roles.py

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3fee258c483248c70aee1c1895f75