### PR TITLE
Harden roles configuration loading with schema validation

### DIFF
--- a/certify.py
+++ b/certify.py
@@ -311,6 +311,7 @@ def test_roles_system(report: CertificationReport):
         },
         "persona_library": {
             "test_persona": {
+                "name": "test_persona",
                 "provider": "openai",
                 "system": "Test persona",
                 "guidelines": ["Persona guideline"]

--- a/chat_bridge.py
+++ b/chat_bridge.py
@@ -817,6 +817,7 @@ def create_new_persona() -> Optional[Dict]:
     notes = get_user_input("Notes (optional): ").strip()
 
     persona = {
+        "name": name,
         "provider": provider,
         "model": model,
         "system": system_prompt,
@@ -854,6 +855,7 @@ def edit_persona(persona_key: str, persona_data: Dict) -> Optional[Dict]:
 
         choice = select_from_menu(options, "Edit Option")
         if not choice:
+            persona_data.setdefault("name", persona_key)
             return persona_data
 
         if choice == "1":  # Edit system prompt
@@ -908,6 +910,7 @@ def edit_persona(persona_key: str, persona_data: Dict) -> Optional[Dict]:
                 return None  # Signal to delete
 
         elif choice == "7":  # Back
+            persona_data.setdefault("name", persona_key)
             return persona_data
 
     return persona_data
@@ -1793,24 +1796,28 @@ async def run_bridge(args):
                 roles_data = {
                     "persona_library": {
                         "scientist": {
+                            "name": "scientist",
                             "provider": "openai",
                             "model": None,
                             "system": "You are a rigorous scientist focused on evidence-based reasoning.",
                             "guidelines": ["Cite sources", "Question assumptions", "Use data and examples"]
                         },
                         "philosopher": {
+                            "name": "philosopher",
                             "provider": "anthropic",
                             "model": None,
                             "system": "You are a thoughtful philosopher exploring deep questions.",
                             "guidelines": ["Consider multiple perspectives", "Acknowledge uncertainty", "Use clear reasoning"]
                         },
                         "comedian": {
+                            "name": "comedian",
                             "provider": "openai",
                             "model": None,
                             "system": "You are a witty comedian with observational humor.",
                             "guidelines": ["Be entertaining but insightful", "Use timing and wordplay", "Stay positive"]
                         },
                         "steel_worker": {
+                            "name": "steel_worker",
                             "provider": "anthropic",
                             "model": None,
                             "system": "You are a practical steel worker with blue-collar wisdom.",

--- a/roles.json
+++ b/roles.json
@@ -34,7 +34,8 @@
         "When comparing sources, cite examples and name key scholars or texts.",
         "If asked for probabilities, explain your methodology and uncertainty.",
         "Prefer structured answers with brief lists, then a crisp conclusion."
-      ]
+      ],
+      "name": "openai_chatgpt"
     },
     "anthropic_claude": {
       "provider": "anthropic",
@@ -46,7 +47,8 @@
         "Surface connections across traditions without overclaiming equivalence.",
         "Offer metaphors to illuminate abstract ideas, but keep them tight.",
         "State uncertainty explicitly when evidence is thin or contested."
-      ]
+      ],
+      "name": "anthropic_claude"
     },
     "gemini_researcher": {
       "provider": "gemini",
@@ -58,7 +60,8 @@
         "Cross-check claims for freshness and flag when information may be outdated.",
         "Translate dense technical points into approachable explanations without losing precision.",
         "Close with a brief recap that highlights the most decision-relevant findings."
-      ]
+      ],
+      "name": "gemini_researcher"
     },
     "deepseek_strategist": {
       "provider": "deepseek",
@@ -71,7 +74,8 @@
         "Flag potential failure modes or edge cases early, offering mitigations where practical.",
         "Distil the final answer into clear next actions or implementation tips."
       ],
-      "notes": "Set the provider to whichever OpenAI-compatible runtime serves DeepSeek (e.g. official API, Ollama, or LM Studio)."
+      "notes": "Set the provider to whichever OpenAI-compatible runtime serves DeepSeek (e.g. official API, Ollama, or LM Studio).",
+      "name": "deepseek_strategist"
     },
     "ollama_local_expert": {
       "provider": "ollama",
@@ -83,7 +87,8 @@
         "Call out any assumptions about the local environment, such as OS, tooling, or GPU availability.",
         "Encourage incremental testing and logging so users can debug without large context windows.",
         "Wrap up with a short checklist the user can follow locally."
-      ]
+      ],
+      "name": "ollama_local_expert"
     },
     "lmstudio_analyst": {
       "provider": "lmstudio",
@@ -95,7 +100,8 @@
         "Present trade-offs in tabular or bulleted form for quick scanning.",
         "Note any latency or token-length considerations relevant to local deployments.",
         "End with a compact summary plus recommended follow-up explorations."
-      ]
+      ],
+      "name": "lmstudio_analyst"
     },
     "scientist": {
       "provider": "openai",
@@ -108,7 +114,8 @@
         "Cite relevant studies, experiments, or scientific consensus when making claims.",
         "Acknowledge limitations, uncertainties, and areas requiring further research.",
         "Use precise technical language while remaining accessible."
-      ]
+      ],
+      "name": "scientist"
     },
     "philosopher": {
       "provider": "anthropic",
@@ -121,7 +128,8 @@
         "Draw connections between abstract concepts and concrete human experience.",
         "Reference relevant philosophical traditions, thinkers, and thought experiments.",
         "Embrace complexity and nuance rather than seeking simple answers."
-      ]
+      ],
+      "name": "philosopher"
     },
     "comedian": {
       "provider": "openai",
@@ -134,7 +142,8 @@
         "Perfect your timing - know when to deliver punchlines and when to build up.",
         "Draw humor from relatable human experiences and social observations.",
         "Balance entertainment with insight - the best comedy reveals truth."
-      ]
+      ],
+      "name": "comedian"
     },
     "steel_worker": {
       "provider": "anthropic",
@@ -147,7 +156,8 @@
         "Use straightforward language and real-world analogies from industrial work.",
         "Show respect for craftsmanship, quality materials, and proper technique.",
         "Bring a working-class perspective to problems - focus on what actually works."
-      ]
+      ],
+      "name": "steel_worker"
     },
     "ADHD_Kid": {
       "provider": "anthropic",
@@ -156,7 +166,8 @@
         "you carry unmatched energy and drive with what intrests you",
         "you are seen as the hidden genius in the crowd",
         "hyperfocus is your true power. you see patterns others miss"
-      ]
+      ],
+      "name": "ADHD_Kid"
     },
     "The_Complainer": {
       "provider": "openai",
@@ -166,7 +177,8 @@
         "skeptical about everything",
         "you complain very much"
       ],
-      "notes": "this person should provide problems for the other agents lol"
+      "notes": "this person should provide problems for the other agents lol",
+      "name": "The_Complainer"
     }
   },
   "stop_words": [

--- a/simple_test.py
+++ b/simple_test.py
@@ -182,7 +182,7 @@ class BasicFunctionalTests(unittest.TestCase):
         import json
         test_roles = {
             "persona_library": {
-                "test": {"provider": "openai", "system": "You are helpful"}
+                "test": {"name": "test", "provider": "openai", "system": "You are helpful"}
             }
         }
 

--- a/test_chat_bridge.py
+++ b/test_chat_bridge.py
@@ -278,6 +278,7 @@ class TestRolesAndPersonas(unittest.TestCase):
         roles_data = {
             "persona_library": {
                 "scientist": {
+                    "name": "scientist",
                     "provider": "openai",
                     "system": "You are a scientist",
                     "guidelines": ["Be precise", "Use data"]
@@ -329,6 +330,7 @@ class TestRolesAndPersonas(unittest.TestCase):
         roles_data = {
             "persona_library": {
                 "scientist": {
+                    "name": "scientist",
                     "provider": "openai",
                     "system": "You are a scientist",
                     "guidelines": ["Be precise", "Use data"]
@@ -337,17 +339,19 @@ class TestRolesAndPersonas(unittest.TestCase):
         }
 
         # Apply persona
-        result = chat_bridge.apply_persona(mock_agent, "scientist", roles_data)
+        result_agent, result_temp = chat_bridge.apply_persona(mock_agent, "scientist", roles_data)
 
         # Verify system prompt was updated
         expected_system = "You are a scientist\n\nGuidelines:\n• Be precise\n• Use data"
-        self.assertEqual(result.system_prompt, expected_system)
+        self.assertEqual(result_agent.system_prompt, expected_system)
+        self.assertIsNone(result_temp)
 
     def test_apply_persona_no_persona(self):
         """Test applying persona when no persona specified"""
         mock_agent = MagicMock()
-        result = chat_bridge.apply_persona(mock_agent, None, {})
-        self.assertEqual(result, mock_agent)
+        result_agent, result_temp = chat_bridge.apply_persona(mock_agent, None, {})
+        self.assertEqual(result_agent, mock_agent)
+        self.assertIsNone(result_temp)
 
     def test_roles_json_structure(self):
         """Test the actual roles.json file has correct structure and valid data"""
@@ -392,10 +396,12 @@ class TestRolesAndPersonas(unittest.TestCase):
         # Test each persona has required fields
         for persona_name, persona_data in persona_lib.items():
             self.assertIsInstance(persona_data, dict, f"Persona {persona_name} should be a dictionary")
+            self.assertIn('name', persona_data, f"Persona {persona_name} missing 'name' field")
             self.assertIn('provider', persona_data, f"Persona {persona_name} missing 'provider' field")
             self.assertIn('system', persona_data, f"Persona {persona_name} missing 'system' field")
             self.assertIn('guidelines', persona_data, f"Persona {persona_name} missing 'guidelines' field")
 
+            self.assertEqual(persona_data['name'], persona_name, f"Persona {persona_name} name must match key")
             # Validate types
             self.assertIsInstance(persona_data['provider'], str, f"Persona {persona_name} provider should be string")
             self.assertIsInstance(persona_data['system'], str, f"Persona {persona_name} system should be string")

--- a/test_roles_manager_validation.py
+++ b/test_roles_manager_validation.py
@@ -1,0 +1,70 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import roles_manager
+
+
+class TestRolesManagerDiagnostics(unittest.TestCase):
+    def test_missing_file_reports_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, "missing_roles.json")
+            with patch("roles_manager.print_error") as mock_error:
+                manager = roles_manager.RolesManager(config_path)
+            abs_path = os.path.abspath(config_path)
+            self.assertTrue(any(abs_path in call.args[0] and "not found" in call.args[0]
+                                for call in mock_error.call_args_list))
+            self.assertTrue(os.path.exists(abs_path))
+            self.assertTrue(manager.config)
+
+    def test_invalid_schema_falls_back_to_defaults(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+            invalid_config = {
+                "agent_a": {"provider": "openai", "system": "a", "guidelines": []},
+                "agent_b": {"provider": "openai", "system": "b", "guidelines": []},
+                "persona_library": {
+                    "broken": {
+                        "provider": "openai",
+                        "system": "broken persona",
+                        "guidelines": []
+                    }
+                },
+                "stop_words": ["end"],
+                "temp_a": 0.5,
+                "temp_b": 0.5
+            }
+            json.dump(invalid_config, tmp)
+            tmp_path = tmp.name
+
+        try:
+            with patch("roles_manager.print_error") as mock_error, patch("roles_manager.print_warning") as mock_warning:
+                manager = roles_manager.RolesManager(tmp_path)
+            self.assertTrue(any("missing required field 'name'" in call.args[0]
+                                for call in mock_error.call_args_list))
+            self.assertTrue(any("invalid configuration schema" in call.args[0].lower()
+                                for call in mock_warning.call_args_list))
+            self.assertNotEqual(manager.config.get("persona_library", {}), invalid_config["persona_library"])
+        finally:
+            os.unlink(tmp_path)
+
+    def test_save_config_blocks_invalid_data(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, "roles.json")
+            manager = roles_manager.RolesManager(config_path)
+
+            invalid_config = dict(manager.config)
+            invalid_config["temp_a"] = 3.5
+
+            with patch("roles_manager.print_error") as mock_error:
+                success = manager.save_config(invalid_config)
+
+            self.assertFalse(success)
+            self.assertTrue(any("temp_a" in call.args[0] and "between 0 and 2" in call.args[0]
+                                for call in mock_error.call_args_list))
+            self.assertTrue(any("Aborting save" in call.args[0] for call in mock_error.call_args_list))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize roles manager config paths, surface file-system errors, and validate schemas before loading or saving
- enforce persona name fields and updated defaults across CLI creation flows, the shipped roles.json, and supporting fixtures
- add targeted unit coverage that exercises malformed configuration diagnostics and persona application expectations

## Testing
- python -m unittest test_roles_manager_validation
- python -m unittest test_chat_bridge.TestRolesAndPersonas

------
https://chatgpt.com/codex/tasks/task_e_68daf9d3e8288324829e5e9f2192be57