### PR TITLE
Improve web conversation credential error handling

### DIFF
--- a/web_gui/backend/web_gui/backend/main.py
+++ b/web_gui/backend/web_gui/backend/main.py
@@ -82,31 +82,41 @@ class Conversation:
         self.agent_b = None
         self.active = True
 
-    def initialize_agents(self):
-        """Initialize AI agents for the conversation"""
-        try:
-            # Resolve models
-            model_a = resolve_model(self.request.provider_a, None)
-            model_b = resolve_model(self.request.provider_b, None)
+    def initialize_agents(self) -> None:
+        """Initialize AI agents for the conversation.
 
-            # Ensure credentials
-            ensure_credentials(self.request.provider_a)
-            ensure_credentials(self.request.provider_b)
+        Raises:
+            RuntimeError: If provider configuration is invalid or
+                credentials are missing.
+        """
 
-            # Create agents
-            self.agent_a = create_agent("A", self.request.provider_a, model_a,
-                                      self.request.temperature_a,
-                                      get_spec(self.request.provider_a).default_system)
+        model_a = resolve_model(self.request.provider_a, None)
+        model_b = resolve_model(self.request.provider_b, None)
 
-            self.agent_b = create_agent("B", self.request.provider_b, model_b,
-                                      self.request.temperature_b,
-                                      get_spec(self.request.provider_b).default_system)
+        ensure_credentials(self.request.provider_a)
+        ensure_credentials(self.request.provider_b)
 
-            logger.info(f"Agents initialized: {self.request.provider_a} vs {self.request.provider_b}")
-            return True
-        except Exception as e:
-            logger.error(f"Failed to initialize agents: {e}")
-            return False
+        self.agent_a = create_agent(
+            "A",
+            self.request.provider_a,
+            model_a,
+            self.request.temperature_a,
+            get_spec(self.request.provider_a).default_system,
+        )
+
+        self.agent_b = create_agent(
+            "B",
+            self.request.provider_b,
+            model_b,
+            self.request.temperature_b,
+            get_spec(self.request.provider_b).default_system,
+        )
+
+        logger.info(
+            "Agents initialized: %s vs %s",
+            self.request.provider_a,
+            self.request.provider_b,
+        )
 
 class PersonaManager:
     """Manages roles and personalities configuration"""
@@ -159,16 +169,32 @@ class PersonaManager:
 
     def get_available_personas(self) -> Dict[str, Dict]:
         """Get available personas in API format"""
-        return {
-            key: {
+        available: Dict[str, Dict] = {}
+        for key, persona in self.persona_library.items():
+            try:
+                spec = get_spec(persona.provider)
+            except KeyError:
+                logger.warning("Skipping persona %s due to unknown provider '%s'", key, persona.provider)
+                continue
+
+            if spec.needs_key and not os.getenv(spec.key_env or ""):
+                logger.info(
+                    "Skipping persona %s because %s credentials (%s) are not configured",
+                    key,
+                    spec.label,
+                    spec.key_env,
+                )
+                continue
+
+            available[key] = {
                 "id": key,
                 "name": persona.name,
                 "provider": persona.provider,
                 "description": f"AI persona using {persona.provider}",
                 "system_preview": persona.system_prompt[:100] + "..." if len(persona.system_prompt) > 100 else persona.system_prompt
             }
-            for key, persona in self.persona_library.items()
-        }
+
+        return available
 
 # Global state (in production, use Redis or database)
 conversations: Dict[str, Conversation] = {}
@@ -214,10 +240,8 @@ async def create_conversation(request: ConversationRequest):
         conversation = Conversation(request)
         conversations[conv_id] = conversation
 
-        # Initialize agents
-        success = conversation.initialize_agents()  # Remove await since create_agent is synchronous
-        if not success:
-            raise HTTPException(status_code=500, detail="Failed to initialize agents")
+        # Initialize agents (raises when credentials are missing)
+        conversation.initialize_agents()
 
         # Add initial user message
         initial_message = Message(
@@ -234,9 +258,12 @@ async def create_conversation(request: ConversationRequest):
             "starter_message": request.starter_message
         }
 
+    except RuntimeError as e:
+        logger.error("Failed to create conversation due to configuration issue: %s", e)
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Failed to create conversation: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("Failed to create conversation: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e
 
 @app.websocket("/ws/conversations/{conversation_id}")
 async def websocket_conversation(websocket: WebSocket, conversation_id: str):

--- a/web_gui/frontend/src/App.tsx
+++ b/web_gui/frontend/src/App.tsx
@@ -39,15 +39,34 @@ function App() {
       });
 
       if (!response.ok) {
-        throw new Error('Failed to start conversation');
+        let message = 'Failed to start conversation';
+        const clonedResponse = response.clone();
+        try {
+          const errorBody = await clonedResponse.json();
+          if (errorBody && typeof errorBody.detail === 'string') {
+            message = errorBody.detail;
+          }
+        } catch (parseError) {
+          try {
+            const text = await response.text();
+            if (text) {
+              message = text;
+            }
+          } catch {
+            // Ignore secondary parsing errors
+          }
+        }
+
+        throw new Error(message);
       }
 
       const data: ConversationResponse = await response.json();
       setConversationId(data.conversation_id);
       setSetupComplete(true);
     } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to start conversation';
       console.error('Failed to start conversation:', error);
-      alert('Failed to start conversation. Please try again.');
+      alert(message);
     }
   };
 


### PR DESCRIPTION
## Summary
- raise and surface provider credential configuration errors when creating conversations
- hide personas that require missing API keys so users only see runnable options
- show backend error details in the frontend setup wizard alert

## Testing
- `npm run type-check` *(fails: Missing script "type-check")*

------
https://chatgpt.com/codex/tasks/task_e_68e7c4d786e08324915c935af62507d7