### PR TITLE
Remove persona credential gating and add provider selectors

### DIFF
--- a/web_gui/frontend/src/App.tsx
+++ b/web_gui/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { Persona, Provider, ConversationRequest, ConversationResponse } from './
 
 function App() {
   const [personas, setPersonas] = useState<Persona[]>([]);
-  const [providers] = useState<Provider[]>([]);
+  const [providers, setProviders] = useState<Provider[]>([]);
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [selectedPersonas, setSelectedPersonas] = useState<{
     agentA?: Persona;
@@ -16,6 +16,7 @@ function App() {
   useEffect(() => {
     // Load available personas on app start
     fetchPersonas();
+    fetchProviders();
   }, []);
 
   const fetchPersonas = async () => {
@@ -25,6 +26,16 @@ function App() {
       setPersonas(data.personas || []);
     } catch (error) {
       console.error('Failed to load personas:', error);
+    }
+  };
+
+  const fetchProviders = async () => {
+    try {
+      const response = await fetch('/api/providers');
+      const data = await response.json();
+      setProviders(data.providers || []);
+    } catch (error) {
+      console.error('Failed to load providers:', error);
     }
   };
 

--- a/web_gui/frontend/src/components/PersonaSelector.tsx
+++ b/web_gui/frontend/src/components/PersonaSelector.tsx
@@ -29,11 +29,15 @@ export function PersonaSelector({
         className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
       >
         <option value="">Default AI ({agentName})</option>
-        {personas.map(persona => (
-          <option key={persona.id} value={persona.id}>
-            🎭 {persona.name} ({persona.provider})
-          </option>
-        ))}
+        {personas.map(persona => {
+          const providerLabel = persona.provider_label || persona.provider;
+          const providerSuffix = providerLabel ? ` (${providerLabel})` : '';
+          return (
+            <option key={persona.id} value={persona.id}>
+              🎭 {persona.name}{providerSuffix}
+            </option>
+          );
+        })}
       </select>
       
       {selectedPersona && selectedPersona.system_preview && (

--- a/web_gui/frontend/src/types/index.ts
+++ b/web_gui/frontend/src/types/index.ts
@@ -1,7 +1,8 @@
 export interface Persona {
   id: string;
   name: string;
-  provider: string;
+  provider?: string;
+  provider_label?: string;
   description?: string;
   system_preview?: string;
 }


### PR DESCRIPTION
## Summary
- replace the FastAPI startup event with a lifespan handler to silence the deprecation warning
- allow persona definitions to load without enforcing provider credentials while exposing optional provider metadata
- fetch providers in the web UI and add explicit provider selectors so personas are no longer tied to credentials

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'inquirer')*


------
https://chatgpt.com/codex/tasks/task_e_68e7c804e5408324933c6c4fd87e17e5