### PR TITLE
Refactor MCP status checker for structured output

### DIFF
--- a/check_mcp_status.py
+++ b/check_mcp_status.py
@@ -1,173 +1,218 @@
 #!/usr/bin/env python3
-"""
-MCP Status Checker
-Verifies FastMCP server and database content.
-"""
+"""MCP Status Checker with clearer flow and error handling."""
 
-import sqlite3
-import sys
+from __future__ import annotations
+
 import asyncio
-import subprocess
+import sqlite3
+from contextlib import closing
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Awaitable, Callable, Dict, Iterable, Optional, Sequence
+
 from fastmcp.client import Client, PythonStdioTransport
 
 
-def check_db():
-    """Check database content."""
-    db_path = Path('bridge.db')
+# Data containers keep output predictable and testable
+@dataclass
+class DatabaseStatus:
+    status: str
+    tables: Dict[str, int] = field(default_factory=dict)
+    message: Optional[str] = None
+
+
+@dataclass
+class ServerStatus:
+    status: str
+    resources: int = 0
+    tools: int = 0
+    health: str = "Not available"
+    error: Optional[str] = None
+
+
+@dataclass
+class LogStatus:
+    transcripts: int
+    logs: int
+
+
+@dataclass
+class ToolTestResult:
+    status: str
+    message: Optional[str] = None
+    sample_id: Optional[str] = None
+
+
+def check_db(db_path: Path = Path("bridge.db")) -> DatabaseStatus:
+    """Check database content and table counts with friendly errors."""
+
     if not db_path.exists():
-        return {"status": "error", "message": "Database not found"}
+        return DatabaseStatus(status="error", message="Database not found")
 
     try:
-        conn = sqlite3.connect(db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(db_path)) as conn:
+            cursor = conn.cursor()
+            table_counts: Dict[str, int] = {}
+            for table in ("conversations", "messages"):
+                cursor.execute(f"SELECT COUNT(*) FROM {table}")
+                count_row = cursor.fetchone()
+                table_counts[table] = int(count_row[0] if count_row else 0)
 
-        # Check tables
-        tables = ['conversations', 'messages']
-        table_status = {}
-        for table in tables:
-            cursor.execute(f"SELECT COUNT(*) FROM {table}")
-            count = cursor.fetchone()[0]
-            table_status[table] = count
-
-        conn.close()
-        return {"status": "ok", "tables": table_status}
-
-    except Exception as e:
-        return {"status": "error", "message": str(e)}
+        return DatabaseStatus(status="ok", tables=table_counts)
+    except sqlite3.Error as exc:  # Explicit SQLite error surfaces actionable info
+        return DatabaseStatus(status="error", message=str(exc))
+    except Exception as exc:  # Fallback for unexpected issues
+        return DatabaseStatus(status="error", message=str(exc))
 
 
-async def check_mcp_server_async():
-    """Check FastMCP server health via stdio."""
+async def _with_mcp_client(
+    server_script: str,
+    action: Callable[[Client], Awaitable[ServerStatus]],
+) -> ServerStatus:
+    """Create a client, run an async action, and surface errors."""
+
+    transport = PythonStdioTransport(server_script)
+    async with Client(transport) as client:
+        return await action(client)
+
+
+async def check_mcp_server_async(server_script: str = "mcp_server.py") -> ServerStatus:
+    """Check FastMCP server health via stdio transport."""
+
+    async def run(client: Client) -> ServerStatus:
+        resources = await client.list_resources()
+        tools = await client.list_tools()
+        health_text = await _extract_health(resources, client)
+        return ServerStatus(
+            status="ok",
+            resources=len(resources),
+            tools=len(tools),
+            health=health_text,
+        )
+
     try:
-        # Create stdio transport for Python MCP server
-        transport = PythonStdioTransport("mcp_server.py")
-
-        async with Client(transport) as client:
-            # List available resources
-            resources = await client.list_resources()
-
-            # Try to read the health resource
-            health_resource = None
-            for resource in resources:
-                if "health" in str(resource.uri):
-                    health_resource = await client.read_resource(str(resource.uri))
-                    break
-
-            # List available tools
-            tools = await client.list_tools()
-
-            health_text = "Not available"
-            if health_resource:
-                # health_resource is a list of ReadResourceResult
-                if isinstance(health_resource, list) and len(health_resource) > 0:
-                    health_text = health_resource[0].text if hasattr(health_resource[0], 'text') else str(health_resource[0])
-                elif hasattr(health_resource, 'text'):
-                    health_text = health_resource.text
-
-            return {
-                "status": "ok",
-                "resources": len(resources),
-                "tools": len(tools),
-                "health": health_text
-            }
-    except Exception as e:
-        return {"status": "offline", "error": str(e)}
+        return await _with_mcp_client(server_script, run)
+    except Exception as exc:
+        return ServerStatus(status="offline", error=str(exc))
 
 
-def check_mcp_server():
-    """Check FastMCP server health (sync wrapper)."""
+def check_mcp_server(server_script: str = "mcp_server.py") -> ServerStatus:
+    """Synchronously wrap the async server probe for CLI use."""
+
     try:
-        return asyncio.run(check_mcp_server_async())
-    except Exception as e:
-        return {"status": "offline", "error": str(e)}
+        return asyncio.run(check_mcp_server_async(server_script))
+    except Exception as exc:
+        return ServerStatus(status="offline", error=str(exc))
 
 
-def check_log_files():
-    """Check available log files."""
-    transcript_dir = Path('transcripts')
-    logs_dir = Path('logs')
+async def _extract_health(resources: Sequence, client: Client) -> str:
+    """Return health text if a resource with 'health' in its URI exists."""
 
-    transcript_count = len(list(transcript_dir.glob('*.md'))) if transcript_dir.exists() else 0
-    log_count = len(list(logs_dir.glob('*.log'))) if logs_dir.exists() else 0
+    for resource in resources:
+        if "health" in str(resource.uri):
+            resource_content = await client.read_resource(str(resource.uri))
+            if isinstance(resource_content, Iterable) and not isinstance(resource_content, (str, bytes)):
+                resource_content = next(iter(resource_content), None)
 
-    return {
-        "transcripts": transcript_count,
-        "logs": log_count
-    }
+            if hasattr(resource_content, "text"):
+                return getattr(resource_content, "text") or "Not available"
+            return str(resource_content)
+    return "Not available"
 
 
-async def test_mcp_tools():
-    """Test MCP tools by calling them via stdio."""
+def check_log_files(
+    transcript_dir: Path = Path("transcripts"),
+    logs_dir: Path = Path("logs"),
+) -> LogStatus:
+    """Summarise available transcript and session log files."""
+
+    transcript_count = len(list(transcript_dir.glob("*.md"))) if transcript_dir.exists() else 0
+    log_count = len(list(logs_dir.glob("*.log"))) if logs_dir.exists() else 0
+    return LogStatus(transcripts=transcript_count, logs=log_count)
+
+
+async def test_mcp_tools(server_script: str = "mcp_server.py") -> ToolTestResult:
+    """Test MCP tools by calling them via stdio transport."""
+
+    async def run(client: Client) -> ToolTestResult:
+        result = await client.call_tool("get_recent_chats", {"limit": 1})
+        sample_items = getattr(result, "data", []) or []
+        sample_id = _extract_id(sample_items[0]) if sample_items else None
+        return ToolTestResult(status="ok", sample_id=sample_id)
+
     try:
-        # Create stdio transport for Python MCP server
-        transport = PythonStdioTransport("mcp_server.py")
-
-        async with Client(transport) as client:
-            # Test get_recent_chats tool
-            result = await client.call_tool("get_recent_chats", {"limit": 1})
-            return {"status": "ok", "sample_data": result.data}
-    except Exception as e:
-        return {"status": "error", "message": str(e)}
+        return await _with_mcp_client(server_script, run)
+    except Exception as exc:
+        return ToolTestResult(status="error", message=str(exc))
 
 
-def main():
+def _extract_id(item: object) -> str:
+    """Extract an identifier from FastMCP responses that vary in shape."""
+
+    if isinstance(item, dict):
+        return str(item.get("id", "N/A"))
+    return str(getattr(item, "id", "N/A"))
+
+
+def _print_database_status(status: DatabaseStatus) -> None:
+    print("📊 Database Status:")
+    if status.status == "ok":
+        print("  ✅ Database: FOUND")
+        for table, count in status.tables.items():
+            print(f"  📦 {table}: {count} entries")
+    else:
+        print(f"  ❌ Database: {status.message}")
+
+
+def _print_server_status(status: ServerStatus) -> None:
+    print("\n🚀 FastMCP Server Status:")
+    if status.status == "ok":
+        print("  ✅ Server: ACCESSIBLE")
+        print("  📍 Transport: stdio")
+        print(f"  🛠️  Tools available: {status.tools}")
+        print(f"  📦 Resources available: {status.resources}")
+        print(f"  🩺 Health: {status.health}")
+    else:
+        print(f"  ❌ Server: {status.error or 'Unknown error'}")
+
+
+def _print_log_status(status: LogStatus) -> None:
+    print("\n🏗️  Log Files Available:")
+    print(f"  📄 Transcripts: {status.transcripts} files")
+    print(f"  📝 Session logs: {status.logs} files")
+
+
+def _print_tool_test(result: ToolTestResult) -> None:
+    print("\n🧪 Testing MCP Tools:")
+    if result.status == "ok":
+        print("  ✅ Tools: WORKING")
+        if result.sample_id:
+            print(f"  🔄 Recent conversation: {result.sample_id}")
+    else:
+        print(f"  ⚠️  Tools test failed: {result.message or 'Unknown error'}")
+
+
+def main() -> int:
     print("🔍 MCP SYSTEM STATUS CHECK (FastMCP)")
     print("=" * 50)
 
-    # Check database
-    print("📊 Database Status:")
     db_status = check_db()
-    if db_status["status"] == "ok":
-        print("  ✅ Database: FOUND")
-        for table, count in db_status["tables"].items():
-            print(f"  📦 {table}: {count} entries")
-    else:
-        print(f"  ❌ Database: {db_status}")
+    _print_database_status(db_status)
 
-    # Check MCP server
-    print("\n🚀 FastMCP Server Status:")
     server_status = check_mcp_server()
-    if server_status["status"] == "ok":
-        print("  ✅ Server: ACCESSIBLE")
-        print(f"  📍 Transport: stdio")
-        print(f"  🛠️  Tools available: {server_status.get('tools', 0)}")
-        print(f"  📦 Resources available: {server_status.get('resources', 0)}")
-    else:
-        print(f"  ❌ Server: {server_status.get('error', 'Unknown error')}")
+    _print_server_status(server_status)
 
-    # Check log files
-    print("\n🏗️  Log Files Available:")
     log_status = check_log_files()
-    print(f"  📄 Transcripts: {log_status['transcripts']} files")
-    print(f"  📝 Session logs: {log_status['logs']} files")
+    _print_log_status(log_status)
 
-    # Test MCP tools
-    if server_status["status"] == "ok":
-        print("\n🧪 Testing MCP Tools:")
-        test_result = asyncio.run(test_mcp_tools())
-        if test_result["status"] == "ok":
-            print("  ✅ Tools: WORKING")
-            sample = test_result.get("sample_data", [])
-            if sample and len(sample) > 0:
-                # Handle different data types returned by FastMCP
-                first_item = sample[0]
-                if isinstance(first_item, dict):
-                    conv_id = first_item.get('id', 'N/A')
-                else:
-                    conv_id = getattr(first_item, 'id', 'N/A')
-                print(f"  🔄 Recent conversation: {conv_id}")
-        else:
-            print(f"  ⚠️  Tools test failed: {test_result.get('message', 'Unknown')}")
+    if server_status.status == "ok":
+        tool_result = asyncio.run(test_mcp_tools())
+        _print_tool_test(tool_result)
 
-    # Summary
     print("\n" + "=" * 50)
     print("✨ SUMMARY:")
-    all_good = (
-        db_status["status"] == "ok" and
-        server_status["status"] == "ok" and
-        log_status['transcripts'] + log_status['logs'] > 0
-    )
+    has_logs = log_status.transcripts + log_status.logs > 0
+    all_good = db_status.status == "ok" and server_status.status == "ok" and has_logs
 
     if all_good:
         print("  ✅ MCP System: FULLY OPERATIONAL")
@@ -175,15 +220,15 @@ def main():
         print("  💡 Using FastMCP 2.0 with stdio transport")
     else:
         print("  ⚠️  MCP System: INCOMPLETE")
-        if db_status["status"] != "ok":
+        if db_status.status != "ok":
             print("    🔧 Run chat_bridge.py first to create database")
-        if server_status["status"] != "ok":
+        if server_status.status != "ok":
             print("    🔧 Ensure mcp_server.py is accessible in the current directory")
-        if log_status['transcripts'] + log_status['logs'] == 0:
+        if not has_logs:
             print("    🔧 Run python populate_mcp_logs.py to import logs")
 
     return 0 if all_good else 1
 
 
 if __name__ == "__main__":
-    exit(main())
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- refactor the MCP status script to use typed status containers and reusable client helpers
- add clearer health checks, log summaries, and tool test reporting with safer parsing
- improve CLI output and error handling for database and server checks

## Testing
- python -m compileall check_mcp_status.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959c51ad92c8324a5245ff4c3cda47f)