### PR TITLE
Fix PHP Artisan test errors

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -77,6 +77,7 @@ class ChatController extends Controller
         ]);
 
         $conversation->messages()->create([
+            'user_id' => auth()->id(),
             'role' => 'user',
             'content' => $validated['starter_message'],
         ]);

--- a/database/migrations/2026_01_19_030344_add_user_id_to_messages_table.php
+++ b/database/migrations/2026_01_19_030344_add_user_id_to_messages_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->foreignId('user_id')->nullable()->after('id')->constrained()->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,11 @@
+<?php
+
+use App\Http\Controllers\ChatController;
+use App\Http\Controllers\PersonaController;
+use App\Http\Controllers\ProfileController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Route;
 
 Route::post('/_boost/browser-logs', function(Request $request) {
     Log::channel('daily')->error('Browser Error', [
@@ -9,3 +15,32 @@ Route::post('/_boost/browser-logs', function(Request $request) {
     ]);
     return response()->json(['status' => 'logged']);
 });
+
+Route::get('/', function () {
+    return redirect()->route('dashboard');
+})->middleware(['auth', 'verified']);
+
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::get('/dashboard', function () {
+        return redirect()->route('chat.index');
+    })->name('dashboard');
+    // Profile routes
+    Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
+    Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
+    Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    // Persona routes
+    Route::resource('personas', PersonaController::class);
+
+    // Chat routes
+    Route::get('/chat', [ChatController::class, 'index'])->name('chat.index');
+    Route::get('/chat/create', [ChatController::class, 'create'])->name('chat.create');
+    Route::post('/chat', [ChatController::class, 'store'])->name('chat.store');
+    Route::get('/chat/search', [ChatController::class, 'search'])->name('chat.search');
+    Route::get('/chat/{conversation}', [ChatController::class, 'show'])->name('chat.show');
+    Route::post('/chat/{conversation}/stop', [ChatController::class, 'stop'])->name('chat.stop');
+    Route::delete('/chat/{conversation}', [ChatController::class, 'destroy'])->name('chat.destroy');
+    Route::get('/chat/{conversation}/transcript', [ChatController::class, 'transcript'])->name('chat.transcript');
+});
+
+require __DIR__.'/auth.php';

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -14,8 +15,10 @@ class ExampleTest extends TestCase
      */
     public function test_the_application_returns_a_successful_response(): void
     {
-        $response = $this->get('/');
+        $user = User::factory()->create();
 
-        $response->assertStatus(200);
+        $response = $this->actingAs($user)->get('/');
+
+        $response->assertRedirect(route('dashboard'));
     }
 }


### PR DESCRIPTION
- Add missing routes for profile, personas, chat, and dashboard
- Add user_id column to messages table via migration
- Update ChatController to set user_id when creating messages
- Add dashboard route for auth redirects
- Update ExampleTest to authenticate user before accessing protected route
- All 32 tests now passing