### PR TITLE
Clear cached bootstrap files during container startup

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,9 @@ set -e
 
 echo "🚀 Starting Chat Bridge Docker initialization..."
 
+# Clear cached framework files to avoid stale package discovery issues
+rm -f /var/www/html/bootstrap/cache/*.php
+
 # Wait for PostgreSQL to be ready
 if [ "${DB_CONNECTION}" = "pgsql" ]; then
     echo "⏳ Waiting for PostgreSQL..."


### PR DESCRIPTION
### Motivation
- Prevent container startup failures where Composer dev packages (like `laravel/pail`) have been removed but stale framework cache still references their service providers, causing errors such as `Class "Laravel\Pail\PailServiceProvider" not found` during `php artisan migrate`.

### Description
- Remove stale framework bootstrap cache files at container start by adding `rm -f /var/www/html/bootstrap/cache/*.php` to `docker-entrypoint.sh` so package discovery entries are not carried over into the runtime container.
- The change is a minimal, safe step executed before waiting for services and running migrations to ensure the application does not attempt to load providers from absent dev dependencies.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696da7384e20832498d0c00c20e445be)