### PR TITLE
fix: Update tests to match schema changes

### DIFF
--- a/database/factories/PersonaFactory.php
+++ b/database/factories/PersonaFactory.php
@@ -18,8 +18,6 @@ class PersonaFactory extends Factory
     {
         return [
             'name' => $this->faker->unique()->name(),
-            'provider' => 'openai',
-            'model' => 'gpt-4o-mini',
             'system_prompt' => $this->faker->sentence(),
             'temperature' => 0.7,
         ];

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -37,7 +37,14 @@ class ChatTest extends TestCase
         $response = $this->actingAs($user)->post('/chat', [
             'persona_a_id' => $personaA->id,
             'persona_b_id' => $personaB->id,
+            'provider_a' => 'openai',
+            'provider_b' => 'openai',
+            'model_a' => 'gpt-4o-mini',
+            'model_b' => 'gpt-4o-mini',
+            'temp_a' => 0.7,
+            'temp_b' => 0.7,
             'starter_message' => 'Hello agents',
+            'max_rounds' => 10,
         ]);
 
         $response->assertRedirect();

--- a/tests/Feature/PersonaTest.php
+++ b/tests/Feature/PersonaTest.php
@@ -22,7 +22,6 @@ class PersonaTest extends TestCase
         $user = User::factory()->create();
         $response = $this->actingAs($user)->post('/personas', [
             'name' => 'Test Persona',
-            'provider' => 'openai',
             'system_prompt' => 'Be helpful',
             'temperature' => 0.7,
         ]);


### PR DESCRIPTION
- Remove provider and model from PersonaFactory after schema migration
- Remove provider from PersonaTest form data
- Add required chat fields (provider_a/b, model_a/b, temp_a/b, max_rounds) to ChatTest to match updated controller validation