### PR TITLE
Add Codex/Boost diagnostics to System Diagnostics page

### DIFF
--- a/resources/js/Pages/Admin/System.jsx
+++ b/resources/js/Pages/Admin/System.jsx
@@ -16,6 +16,14 @@ export default function System({ systemInfo }) {
     const [testingKey, setTestingKey] = useState(false);
     const [clearingKey, setClearingKey] = useState(false);
 
+    const boostAgents = systemInfo.boost?.agents?.length
+        ? systemInfo.boost.agents.join(', ')
+        : 'None';
+    const boostEditors = systemInfo.boost?.editors?.length
+        ? systemInfo.boost.editors.join(', ')
+        : 'None';
+    const mcpDetails = systemInfo.mcp?.details ?? {};
+
     const runAction = async (action, label) => {
         setLoading(true);
         setActiveAction(action);
@@ -150,6 +158,40 @@ export default function System({ systemInfo }) {
                         </div>
                     </div>
 
+                    {/* Codex + Boost Diagnostics */}
+                    <div className="glass-panel rounded-xl p-6 border border-white/5">
+                        <h3 className="text-lg font-bold text-zinc-100 mb-4">Codex + Boost</h3>
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                            <InfoCard label="MCP Mode" value={mcpDetails.mcp_mode ?? 'Unknown'} />
+                            <InfoCard label="MCP Version" value={mcpDetails.version ?? 'Unknown'} />
+                            <InfoCard
+                                label="Vector Search"
+                                value={mcpDetails.vector_search ? 'Enabled' : 'Unavailable'}
+                            />
+                            <InfoCard label="Boost Agents" value={boostAgents} />
+                            <InfoCard label="Boost Editors" value={boostEditors} />
+                            <InfoCard
+                                label="Boost Config"
+                                value={systemInfo.boost?.present ? 'Loaded' : 'Missing'}
+                            />
+                        </div>
+                        <div className="mt-4 flex flex-wrap gap-4">
+                            <StatusBadge
+                                label="Boost Config"
+                                status={systemInfo.boost?.present && !systemInfo.boost?.error}
+                            />
+                            <StatusBadge
+                                label="MCP Health"
+                                status={systemInfo.mcp?.ok}
+                            />
+                        </div>
+                        {systemInfo.boost?.error && (
+                            <div className="mt-4 text-sm text-red-400 font-mono">
+                                Boost config error: {systemInfo.boost.error}
+                            </div>
+                        )}
+                    </div>
+
                     {/* Diagnostic Actions */}
                     <div className="glass-panel rounded-xl p-6 border border-white/5">
                         <h3 className="text-lg font-bold text-zinc-100 mb-4">Diagnostic Actions</h3>
@@ -168,7 +210,7 @@ export default function System({ systemInfo }) {
 
                     {/* OpenAI Service Key */}
                     <div className="glass-panel rounded-xl p-6 border border-white/5">
-                        <h3 className="text-lg font-bold text-zinc-100 mb-4">Codex Service Key</h3>
+                        <h3 className="text-lg font-bold text-zinc-100 mb-4">Codex/Boost Service Key</h3>
                         <p className="text-sm text-zinc-500 mb-4">
                             This single admin key is used for Codex/Boost diagnostics and repair tasks.
                         </p>

--- a/tests/Feature/SystemDiagnosticsTest.php
+++ b/tests/Feature/SystemDiagnosticsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * tests/Feature/SystemDiagnosticsTest.php
+ */
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class SystemDiagnosticsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Ensure the system diagnostics page exposes Codex/Boost details for admins.
+     */
+    public function test_admin_can_view_system_diagnostics_with_boost_details(): void
+    {
+        $admin = User::factory()->create([
+            'role' => 'admin',
+        ]);
+
+        $response = $this->actingAs($admin)->get(route('admin.system'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Admin/System')
+            ->has('systemInfo', fn (AssertableInertia $systemInfo) => $systemInfo
+                ->has('boost', fn (AssertableInertia $boost) => $boost
+                    ->has('present')
+                    ->has('agents')
+                    ->has('editors')
+                    ->has('error')
+                )
+                ->has('mcp', fn (AssertableInertia $mcp) => $mcp
+                    ->has('ok')
+                    ->has('details')
+                )
+                ->etc()
+            )
+        );
+    }
+}

--- a/tests/Fixtures/vite.hot
+++ b/tests/Fixtures/vite.hot
@@ -1,0 +1,1 @@
+http://localhost:5173

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\Vite;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -12,5 +13,7 @@ abstract class TestCase extends BaseTestCase
 
         $this->withoutMiddleware(\Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class);
         $this->withoutMiddleware(\Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class);
+
+        Vite::useHotFile(base_path('tests/Fixtures/vite.hot'));
     }
 }


### PR DESCRIPTION
### Motivation

- Surface Codex/Boost configuration and MCP health in the admin System Diagnostics so administrators can verify the Codex + Boost integration is present and healthy.
- Make the diagnostics page and backend more testable in CI-like environments by avoiding Vite manifest failures during Inertia rendering.

### Description

- Expose Boost and MCP data from the backend by adding `boost` and `mcp` entries to `getSystemInfo()` in `app/Http/Controllers/Admin/SystemController.php` and adding typed return signatures and small formatting improvements; implemented helper methods `getBoostConfig()` and `getMcpHealth()` to read `boost.json` and query the `McpController::health()` endpoint respectively.
- Update the UI at `resources/js/Pages/Admin/System.jsx` to add a dedicated "Codex + Boost" diagnostics panel that displays Boost agents/editors, MCP mode/version/vector-search and shows status badges and any config errors; renamed the service key heading to "Codex/Boost Service Key" for clarity.
- Add a feature test `tests/Feature/SystemDiagnosticsTest.php` that verifies the Inertia payload includes `systemInfo.boost` and `systemInfo.mcp` for admin users, and add a Vite hotfile fixture `tests/Fixtures/vite.hot` plus a test helper change in `tests/TestCase.php` to point Vite at the fixture during tests to prevent manifest errors.

### Testing

- Installed dependencies with `composer install` and ran formatting with `vendor/bin/pint --dirty` (auto-fixed minor style issues), both succeeded.
- Ran the new feature test with `php artisan test --compact tests/Feature/SystemDiagnosticsTest.php --display-warnings`; the test suite completed successfully but emitted a warning about a missing `.env` file in this environment (non-failing warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697528e93c988324bd5b51686f6a3bca)