### PR TITLE
Add ConversationFactory and conversation management tests

### DIFF
--- a/database/factories/ConversationFactory.php
+++ b/database/factories/ConversationFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Persona;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Conversation>
+ */
+class ConversationFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'persona_a_id' => Persona::factory(),
+            'persona_b_id' => Persona::factory(),
+            'provider_a' => 'openai',
+            'provider_b' => 'openai',
+            'model_a' => 'gpt-4o-mini',
+            'model_b' => 'gpt-4o-mini',
+            'temp_a' => 0.7,
+            'temp_b' => 0.7,
+            'starter_message' => $this->faker->sentence(),
+            'status' => 'active',
+            'max_rounds' => 10,
+            'stop_word_detection' => false,
+            'stop_words' => [],
+            'stop_word_threshold' => 0.8,
+        ];
+    }
+
+    /**
+     * Indicate that the conversation is completed.
+     */
+    public function completed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'completed',
+        ]);
+    }
+}

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Feature;
 
 use App\Jobs\RunChatSession;
+use App\Models\Conversation;
 use App\Models\Persona;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
@@ -57,5 +59,43 @@ class ChatTest extends TestCase
         ]);
 
         Queue::assertPushed(RunChatSession::class);
+    }
+
+    public function test_can_view_conversation_show_page(): void
+    {
+        $user = User::factory()->create();
+        $personaA = Persona::factory()->create(['user_id' => $user->id]);
+        $personaB = Persona::factory()->create(['user_id' => $user->id]);
+        $conversation = Conversation::factory()->create([
+            'user_id' => $user->id,
+            'persona_a_id' => $personaA->id,
+            'persona_b_id' => $personaB->id,
+        ]);
+
+        $response = $this->actingAs($user)->get("/chat/{$conversation->id}");
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('Chat/Show')
+            ->has('conversation')
+        );
+    }
+
+    public function test_can_stop_active_conversation(): void
+    {
+        $user = User::factory()->create();
+        $personaA = Persona::factory()->create(['user_id' => $user->id]);
+        $personaB = Persona::factory()->create(['user_id' => $user->id]);
+        $conversation = Conversation::factory()->create([
+            'user_id' => $user->id,
+            'persona_a_id' => $personaA->id,
+            'persona_b_id' => $personaB->id,
+            'status' => 'active',
+        ]);
+
+        $response = $this->actingAs($user)->post("/chat/{$conversation->id}/stop");
+
+        $response->assertRedirect();
+        $this->assertTrue(Cache::has("conversation.stop.{$conversation->id}"));
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a factory for the Conversation model and introduces feature tests for viewing and stopping conversations. These changes improve test coverage and provide a convenient way to generate test conversation data.

## Key Changes
- **Added ConversationFactory**: New factory class for generating Conversation model instances with sensible defaults for testing
  - Includes a `completed()` state modifier for testing completed conversations
  - Sets up default AI provider configurations (OpenAI with gpt-4o-mini)
  - Configures default conversation parameters (temperature, max rounds, stop word detection)

- **Added conversation show page test**: Verifies users can view their conversation details
  - Tests the `/chat/{id}` route returns a 200 status
  - Validates the response renders the `Chat/Show` Inertia component
  - Confirms conversation data is passed to the frontend

- **Added conversation stop test**: Verifies users can stop active conversations
  - Tests the `/chat/{id}/stop` POST endpoint
  - Validates the response redirects appropriately
  - Confirms a cache flag is set to signal conversation termination

## Implementation Details
- The factory creates related User and Persona instances automatically using nested factories
- Both test cases use the factory to create properly configured test data with user ownership
- The stop conversation test validates the cache-based signaling mechanism for stopping active chat sessions

https://claude.ai/code/session_01Na6oHAuXXde12iwHPzSVyz