### PR TITLE
Add return type hints and refactor config access patterns

### DIFF
--- a/app/Http/Controllers/Admin/SystemController.php
+++ b/app/Http/Controllers/Admin/SystemController.php
@@ -682,7 +682,7 @@ PROMPT;
         return [
             'CODEX_API_KEY' => $openaiKey,
             'OPENAI_API_KEY' => $openaiKey,
-            'CODEX_HOME' => config('services.codex.home', env('CODEX_HOME', base_path('.codex'))),
+            'CODEX_HOME' => config('services.codex.home'),
             'TERM' => 'dumb',
             'NO_COLOR' => '1',
             'COLUMNS' => '120',

--- a/app/Http/Controllers/PersonaController.php
+++ b/app/Http/Controllers/PersonaController.php
@@ -3,24 +3,26 @@
 namespace App\Http\Controllers;
 
 use App\Models\Persona;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
+use Inertia\Response as InertiaResponse;
 
 class PersonaController extends Controller
 {
-    public function index()
+    public function index(): InertiaResponse
     {
         return Inertia::render('Personas/Index', [
             'personas' => Persona::latest()->get(),
         ]);
     }
 
-    public function create()
+    public function create(): InertiaResponse
     {
         return Inertia::render('Personas/Create');
     }
 
-    public function store(Request $request)
+    public function store(Request $request): RedirectResponse
     {
         $validated = $request->validate([
             'name' => 'required|string|unique:personas,name',
@@ -35,7 +37,7 @@ class PersonaController extends Controller
         return redirect()->route('personas.index')->with('success', 'Persona created.');
     }
 
-    public function edit(Persona $persona)
+    public function edit(Persona $persona): InertiaResponse
     {
         if ($persona->user_id !== auth()->id()) {
             abort(403);
@@ -46,7 +48,7 @@ class PersonaController extends Controller
         ]);
     }
 
-    public function update(Request $request, Persona $persona)
+    public function update(Request $request, Persona $persona): RedirectResponse
     {
         if ($persona->user_id !== auth()->id()) {
             abort(403);
@@ -65,7 +67,7 @@ class PersonaController extends Controller
         return redirect()->route('personas.index')->with('success', 'Persona updated.');
     }
 
-    public function destroy(Persona $persona)
+    public function destroy(Persona $persona): RedirectResponse
     {
         if ($persona->user_id !== auth()->id()) {
             abort(403);

--- a/app/Http/Middleware/EnsureChatBridgeToken.php
+++ b/app/Http/Middleware/EnsureChatBridgeToken.php
@@ -10,14 +10,7 @@ class EnsureChatBridgeToken
 {
     public function handle(Request $request, Closure $next): Response
     {
-        // If token is not set in env, allow open access (dev mode) or block?
-        // Prompt says: "add a simple token middleware checking header X-CHAT-BRIDGE-TOKEN against env CHAT_BRIDGE_TOKEN"
-        // Implicitly if env is not set, we should probably fail safe or warn.
-        // Let's assume strict: if env is set, check it. If not set, maybe allow or 403.
-        // Let's default to blocking if not set for security, but for "startup" ease, maybe allow if env is empty?
-        // Let's force it.
-
-        $envToken = env('CHAT_BRIDGE_TOKEN');
+        $envToken = config('services.chat_bridge.token');
 
         if (! $envToken) {
             // Warn or skip? Let's skip if no token configured to avoid breaking dev,

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ApiKey extends Model
 {
@@ -27,7 +28,7 @@ class ApiKey extends Model
         'last_validated_at' => 'datetime',
     ];
 
-    public function user()
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }

--- a/app/Models/Persona.php
+++ b/app/Models/Persona.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Persona extends Model
 {
@@ -25,7 +26,7 @@ class Persona extends Model
         'temperature' => 'float',
     ];
 
-    public function user()
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }

--- a/app/Models/Transmission.php
+++ b/app/Models/Transmission.php
@@ -2,8 +2,10 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Str;
 
 class Transmission extends Model
@@ -37,34 +39,26 @@ class Transmission extends Model
         'status' => 'string',
     ];
 
-    /**
-     * Relationship with User
-     */
-    public function user()
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
-    /**
-     * Generate a short unique identifier for the transmission
-     */
-    public function getShortIdAttribute()
+    public function getShortIdAttribute(): string
     {
         return Str::limit(hash('crc32', $this->id.$this->created_at), 8, '');
     }
 
     /**
-     * Scope a query to only include pending transmissions
+     * @param  Builder<Transmission>  $query
+     * @return Builder<Transmission>
      */
-    public function scopePending($query)
+    public function scopePending(Builder $query): Builder
     {
         return $query->where('status', 'pending');
     }
 
-    /**
-     * Mark the transmission as sent
-     */
-    public function markAsSent()
+    public function markAsSent(): void
     {
         $this->update([
             'status' => 'sent',
@@ -73,10 +67,7 @@ class Transmission extends Model
         ]);
     }
 
-    /**
-     * Mark the transmission as failed
-     */
-    public function markAsFailed($errorMessage)
+    public function markAsFailed(string $errorMessage): void
     {
         $this->update([
             'status' => 'failed',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -49,17 +49,17 @@ class User extends Authenticatable
         ];
     }
 
-    public function personas()
+    public function personas(): HasMany
     {
         return $this->hasMany(Persona::class);
     }
 
-    public function conversations()
+    public function conversations(): HasMany
     {
         return $this->hasMany(Conversation::class);
     }
 
-    public function apiKeys()
+    public function apiKeys(): HasMany
     {
         return $this->hasMany(ApiKey::class);
     }

--- a/config/services.php
+++ b/config/services.php
@@ -82,4 +82,8 @@ return [
         'enabled' => env('QDRANT_ENABLED', true),
     ],
 
+    'chat_bridge' => [
+        'token' => env('CHAT_BRIDGE_TOKEN'),
+    ],
+
 ];


### PR DESCRIPTION
## Summary
This PR improves code quality and type safety across the application by adding return type hints to controller and model methods, and refactoring environment variable access to use Laravel's configuration system.

## Key Changes

- **Type Hints**: Added return type declarations to all controller methods in `PersonaController` and model methods across `ApiKey`, `Persona`, `Transmission`, and `User` models
  - Controller methods now explicitly return `InertiaResponse` or `RedirectResponse`
  - Model relationship methods return `BelongsTo` or `HasMany`
  - Model query scopes and utility methods include proper return types

- **Configuration Refactoring**: Migrated direct `env()` calls to use Laravel's configuration system
  - `SystemController`: Changed `CODEX_HOME` to use `config('services.codex.home')` instead of fallback chain
  - `EnsureChatBridgeToken`: Replaced `env('CHAT_BRIDGE_TOKEN')` with `config('services.chat_bridge.token')`
  - Added new `chat_bridge` configuration section in `config/services.php`

- **Import Cleanup**: Added necessary type imports (`RedirectResponse`, `InertiaResponse`, `BelongsTo`, `HasMany`, `Builder`) to support return type hints

## Benefits

- Improved IDE autocomplete and static analysis support
- Better code documentation through explicit return types
- Centralized configuration management following Laravel best practices
- Enhanced maintainability and reduced potential for type-related bugs

https://claude.ai/code/session_016Hq9wyeX1UvfS5Z1fYraan