### PR TITLE
Swap OpenAI/OpenRouter priority and simplify vector search config

### DIFF
--- a/app/Http/Controllers/Admin/BoostDashboardController.php
+++ b/app/Http/Controllers/Admin/BoostDashboardController.php
@@ -191,9 +191,7 @@ class BoostDashboardController extends Controller
 
         $agents = $this->stringListFrom($decoded['agents'] ?? []);
         $editors = $this->stringListFrom($decoded['editors'] ?? []);
-        $vectorSearch = is_bool($decoded['vector_search'] ?? null)
-            ? $decoded['vector_search']
-            : (bool) config('services.qdrant.enabled', false);
+        $vectorSearch = (bool) config('services.qdrant.enabled', false);
 
         return [
             'present' => true,

--- a/app/Services/AI/EmbeddingService.php
+++ b/app/Services/AI/EmbeddingService.php
@@ -13,38 +13,12 @@ class EmbeddingService
     protected string $openRouterBaseUrl = 'https://openrouter.ai/api/v1';
 
     /**
-     * Generate embedding using OpenRouter (primary) or OpenAI (fallback).
+     * Generate embedding using OpenAI (primary) or OpenRouter (fallback on quota exhaustion).
      */
     public function getEmbedding(string $text): array
     {
-        $openRouterKey = $this->resolveApiKey('openrouter');
-
-        if (! empty($openRouterKey)) {
-            $timeout = max(10, (int) config('ai.http_timeout_seconds', 90));
-
-            $response = Http::withHeaders($this->openRouterHeaders($openRouterKey))
-                ->timeout($timeout)
-                ->post("{$this->openRouterBaseUrl}/embeddings", $this->embeddingPayload($this->openRouterEmbeddingModel(), $text));
-
-            if ($response->successful()) {
-                $embedding = $this->extractEmbedding($response);
-                if ($embedding !== null) {
-                    return $embedding;
-                }
-
-                Log::warning('OpenRouter embedding response missing valid vector', [
-                    'status' => $response->status(),
-                    'body' => $response->body(),
-                ]);
-
-                throw new \Exception('OpenRouter Embedding Error: response did not include a valid embedding vector.');
-            }
-
-            throw new \Exception('OpenRouter Embedding Error: '.$response->body());
-        }
-
-        // Fallback to OpenAI when no OpenRouter key is configured.
         $openAiKey = $this->resolveApiKey('openai');
+
         if (empty($openAiKey)) {
             // Return dummy vector for demo/development if no key is available.
             return array_fill(0, 1536, 0.0);
@@ -65,6 +39,35 @@ class EmbeddingService
             ]);
 
             throw new \Exception('OpenAI Embedding Error: response did not include a valid embedding vector.');
+        }
+
+        // Fall back to OpenRouter when OpenAI quota is exhausted.
+        if ($response->status() === 429) {
+            $openRouterKey = $this->resolveApiKey('openrouter');
+
+            if (! empty($openRouterKey)) {
+                $timeout = max(10, (int) config('ai.http_timeout_seconds', 90));
+
+                $orResponse = Http::withHeaders($this->openRouterHeaders($openRouterKey))
+                    ->timeout($timeout)
+                    ->post("{$this->openRouterBaseUrl}/embeddings", $this->embeddingPayload($this->openRouterEmbeddingModel(), $text));
+
+                if ($orResponse->successful()) {
+                    $embedding = $this->extractEmbedding($orResponse);
+                    if ($embedding !== null) {
+                        return $embedding;
+                    }
+
+                    Log::warning('OpenRouter embedding response missing valid vector', [
+                        'status' => $orResponse->status(),
+                        'body' => $orResponse->body(),
+                    ]);
+
+                    throw new \Exception('OpenRouter Embedding Error: response did not include a valid embedding vector.');
+                }
+
+                throw new \Exception('OpenRouter Embedding Error: '.$orResponse->body());
+            }
         }
 
         throw new \Exception('OpenAI Embedding Error: '.$response->body());


### PR DESCRIPTION
## Summary
This PR makes two key changes to improve API resilience and simplify configuration:

1. **Reverses embedding service provider priority**: OpenAI is now the primary provider with OpenRouter as a fallback when OpenAI quota is exhausted (429 status), instead of the previous OpenRouter-first approach.

2. **Simplifies vector search configuration**: Removes dynamic fallback logic in the boost dashboard config reader, now always using the `services.qdrant.enabled` config value directly.

## Key Changes

- **EmbeddingService.php**:
  - Moved OpenAI embedding logic to be the primary attempt
  - Converted OpenRouter to a fallback that only triggers on 429 (quota exhaustion) responses from OpenAI
  - Updated docstring to reflect new provider priority
  - Maintains all error handling and logging for both providers

- **BoostDashboardController.php**:
  - Removed ternary logic that checked for boolean type in decoded config
  - Vector search setting now directly uses `config('services.qdrant.enabled', false)` without fallback to decoded value
  - Simplifies configuration handling by removing conditional logic

## Implementation Details

The embedding service now follows a cleaner fallback pattern: attempt OpenAI first, and only if that request returns a 429 status code (rate limit), attempt OpenRouter as a backup. This provides better cost efficiency while maintaining service availability during quota issues.

https://claude.ai/code/session_01Rrda1TRqXTxdk48FC9mkzf