### PR TITLE
Fix brittle app version test to use runtime APP_VERSION and validate semver

### DIFF
--- a/tests/Feature/AppVersionTest.php
+++ b/tests/Feature/AppVersionTest.php
@@ -8,6 +8,11 @@ class AppVersionTest extends TestCase
 {
     public function test_app_version_is_configured(): void
     {
-        $this->assertSame('1.0.0', config('app.version'));
+        $configuredVersion = (string) config('app.version');
+        $expectedVersion = (string) env('APP_VERSION', '1.0.0');
+
+        $this->assertNotSame('', $configuredVersion);
+        $this->assertSame($expectedVersion, $configuredVersion);
+        $this->assertMatchesRegularExpression('/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/', $configuredVersion);
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent CI failures caused by a hard-coded version expectation when CI copies `.env.example` into the runtime environment, which currently sets `APP_VERSION=0.8.0`.
- Make the test reflect the actual configured application version and surface configuration problems earlier by validating format.

### Description
- Updated `tests/Feature/AppVersionTest.php` to read the configured value via `config('app.version')` and compare it against `env('APP_VERSION', '1.0.0')` instead of asserting a hard-coded `1.0.0` string.
- Added guard assertions to ensure the configured version is non-empty and matches a simple semantic-versioning regular expression.

### Testing
- Ran `php artisan test --compact tests/Feature/AppVersionTest.php`, which passed (`1 passed, 3 assertions`).
- Ran `vendor/bin/pint --dirty`, which passed formatting checks for the modified file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3dea0d8d483249eff60ae2d0517d8)