### PR TITLE
Fix Orchestrator resume flow and harden step input/condition handling

### DIFF
--- a/app/Jobs/ResumeOrchestratorRun.php
+++ b/app/Jobs/ResumeOrchestratorRun.php
@@ -40,9 +40,9 @@ class ResumeOrchestratorRun implements ShouldQueue
         /** @var OrchestratorStep $pausedStep */
         $pausedStep = $pausedStepRun->step;
 
-        $pausedStepRun->update(['status' => 'skipped']);
+        $pausedStepRun->update(['status' => 'approved']);
         $run->update(['status' => 'queued']);
 
-        RunOrchestration::dispatch($run->id, $pausedStep->step_number);
+        RunOrchestration::dispatch($run->id, $pausedStep->step_number, $pausedStep->id);
     }
 }

--- a/app/Jobs/RunOrchestration.php
+++ b/app/Jobs/RunOrchestration.php
@@ -24,14 +24,13 @@ class RunOrchestration implements ShouldQueue
 
     /**
      * The number of seconds the job can run before timing out.
-     *
-     * @var int
      */
     public int $timeout = 3600;
 
     public function __construct(
         public string $runId,
-        public int $startFromStep = 1
+        public int $startFromStep = 1,
+        public ?string $approvedStepId = null
     ) {}
 
     public function handle(OrchestratorService $service): void
@@ -92,7 +91,6 @@ class RunOrchestration implements ShouldQueue
 
         foreach ($steps as $step) {
             /** @var OrchestratorStep $step */
-
             $conditionPassed = $service->evaluateCondition($step->condition, $previousOutput);
 
             $stepRun = OrchestratorStepRun::create([
@@ -104,10 +102,11 @@ class RunOrchestration implements ShouldQueue
 
             if (! $conditionPassed) {
                 $stepRun->update(['status' => 'skipped']);
+
                 continue;
             }
 
-            if ($step->pause_before_run) {
+            if ($step->pause_before_run && $step->id !== $this->approvedStepId) {
                 $stepRun->update(['status' => 'paused']);
                 $run->update(['status' => 'paused']);
                 $stepRun->load('run.orchestration');

--- a/app/Services/Orchestrator/OrchestratorService.php
+++ b/app/Services/Orchestrator/OrchestratorService.php
@@ -6,8 +6,10 @@ use App\Models\Conversation;
 use App\Models\OrchestratorRun;
 use App\Models\OrchestratorStep;
 use Carbon\Carbon;
+use Cron\CronExpression;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class OrchestratorService
 {
@@ -49,7 +51,7 @@ class OrchestratorService
         }
 
         if (isset($condition['regex'])) {
-            return (bool) preg_match('/' . $condition['regex'] . '/i', $output);
+            return $this->matchesRegex((string) $condition['regex'], $output);
         }
 
         return true;
@@ -60,8 +62,10 @@ class OrchestratorService
      */
     public function computeNextRunAt(string $cronExpression, string $timezone): Carbon
     {
-        return \Cron\CronExpression::factory($cronExpression)
+        $nextRunDate = CronExpression::factory($cronExpression)
             ->getNextRunDate('now', 0, false, $timezone);
+
+        return Carbon::instance($nextRunDate);
     }
 
     /**
@@ -104,7 +108,34 @@ class OrchestratorService
      */
     protected function resolveVariable(string $key, array $variables): string
     {
-        return data_get($variables, $key, '') ?? '';
+        $value = data_get($variables, $key, '');
+
+        if ($value === null) {
+            return '';
+        }
+
+        if (is_scalar($value) || $value instanceof \Stringable) {
+            return (string) $value;
+        }
+
+        return json_encode($value, JSON_THROW_ON_ERROR);
+    }
+
+    protected function matchesRegex(string $pattern, string $output): bool
+    {
+        $delimiter = '~';
+        $escapedPattern = str_replace($delimiter, '\\'.$delimiter, $pattern);
+
+        try {
+            return preg_match($delimiter.$escapedPattern.$delimiter.'i', $output) === 1;
+        } catch (\Throwable $e) {
+            Log::warning('Orchestrator condition regex failed', [
+                'regex' => Str::limit($pattern, 200),
+                'error' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
     }
 
     protected function postToWebhook(string $url, string $output, OrchestratorStep $step, OrchestratorRun $run): void

--- a/tests/Feature/OrchestratorControllerTest.php
+++ b/tests/Feature/OrchestratorControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Orchestration;
 use App\Models\OrchestratorRun;
 use App\Models\OrchestratorStep;
+use App\Models\OrchestratorStepRun;
 use App\Models\Persona;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -196,6 +197,40 @@ class OrchestratorControllerTest extends TestCase
         $this->actingAs($user)
             ->post(route('orchestrator.resume', $run->id))
             ->assertForbidden();
+    }
+
+    public function test_resume_job_dispatches_from_approved_paused_step(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $orchestration = Orchestration::factory()->create(['user_id' => $user->id]);
+        $run = OrchestratorRun::factory()->create([
+            'orchestration_id' => $orchestration->id,
+            'user_id' => $user->id,
+            'status' => 'paused',
+        ]);
+        $step = OrchestratorStep::factory()->create([
+            'orchestration_id' => $orchestration->id,
+            'step_number' => 2,
+            'pause_before_run' => true,
+        ]);
+        $stepRun = OrchestratorStepRun::factory()->create([
+            'run_id' => $run->id,
+            'step_id' => $step->id,
+            'status' => 'paused',
+        ]);
+
+        (new \App\Jobs\ResumeOrchestratorRun($run->id))->handle();
+
+        $this->assertDatabaseHas('orchestrator_step_runs', [
+            'id' => $stepRun->id,
+            'status' => 'approved',
+        ]);
+
+        Queue::assertPushed(\App\Jobs\RunOrchestration::class, fn ($job) => $job->runId === $run->id
+            && $job->startFromStep === 2
+            && $job->approvedStepId === $step->id);
     }
 
     public function test_wizard_page_loads(): void

--- a/tests/Unit/OrchestratorServiceTest.php
+++ b/tests/Unit/OrchestratorServiceTest.php
@@ -2,7 +2,10 @@
 
 namespace Tests\Unit;
 
+use App\Models\OrchestratorRun;
+use App\Models\OrchestratorStep;
 use App\Services\Orchestrator\OrchestratorService;
+use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 
 class OrchestratorServiceTest extends TestCase
@@ -12,7 +15,7 @@ class OrchestratorServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->service = new OrchestratorService();
+        $this->service = new OrchestratorService;
     }
 
     public function test_evaluate_condition_returns_true_when_null(): void
@@ -73,5 +76,33 @@ class OrchestratorServiceTest extends TestCase
     public function test_evaluate_condition_with_null_previous_output(): void
     {
         $this->assertFalse($this->service->evaluateCondition(['contains' => 'approved'], null));
+    }
+
+    public function test_evaluate_condition_invalid_regex_returns_false(): void
+    {
+        $this->assertFalse($this->service->evaluateCondition(['regex' => '['], 'Request was approved.'));
+    }
+
+    public function test_resolve_step_input_serializes_array_variables(): void
+    {
+        $step = new OrchestratorStep([
+            'input_source' => 'variable',
+            'input_variable_name' => 'research.findings',
+        ]);
+
+        $run = new OrchestratorRun([
+            'variables' => [
+                'research' => [
+                    'findings' => ['approved' => true],
+                ],
+            ],
+        ]);
+
+        $this->assertSame('{"approved":true}', $this->service->resolveStepInput($step, $run));
+    }
+
+    public function test_compute_next_run_at_returns_carbon_instance(): void
+    {
+        $this->assertInstanceOf(Carbon::class, $this->service->computeNextRunAt('* * * * *', 'UTC'));
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent resumed orchestrations from immediately pausing at the same step and make step input/condition handling more robust. 
- Ensure cron schedule computation returns a usable `Carbon` instance for downstream scheduling. 
- Avoid runtime failures from malformed regexes or non-scalar variable values when resolving step inputs.

### Description
- Hardened `OrchestratorService` by adding `matchesRegex()` to safely evaluate regex conditions, converting array/object variable values to JSON in `resolveVariable()`, and returning a `Carbon` instance from `computeNextRunAt()` using `CronExpression::factory`. (`app/Services/Orchestrator/OrchestratorService.php`).
- Updated `RunOrchestration` to accept an optional `approvedStepId` and skip the `pause_before_run` gate for that approved step so resumed runs do not re-pause at the same step. (`app/Jobs/RunOrchestration.php`).
- Updated `ResumeOrchestratorRun` to mark paused step runs as `approved` and dispatch `RunOrchestration` with the approved step id so the resumed job can continue past the previously-paused step. (`app/Jobs/ResumeOrchestratorRun.php`).
- Added/updated regression tests covering invalid regex handling, array variable resolution (serialisation), cron return type, and resumed-step dispatch behavior. (`tests/Unit/OrchestratorServiceTest.php`, `tests/Feature/OrchestratorControllerTest.php`).

### Testing
- Ran unit and feature tests with `php artisan test --compact tests/Unit/OrchestratorServiceTest.php tests/Feature/OrchestratorControllerTest.php`, and the test run completed successfully (tests passed; test suite emitted warnings from the environment). 
- Ran formatter with `vendor/bin/pint --dirty`, which completed and fixed style issues.
- Verified the relevant tests exercise the new behavior: invalid-regex returns false, step input arrays are serialized, cron schedule returns `Carbon`, and resume flow updates paused step run to `approved` and dispatches `RunOrchestration` with the approved step id.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bd8cd68248324a4bc54d145b4a41e)